### PR TITLE
fix(grid-react): synchronous portal removal in tool panel cleanup

### DIFF
--- a/libs/grid-react/src/lib/portal-bridge.spec.ts
+++ b/libs/grid-react/src/lib/portal-bridge.spec.ts
@@ -201,7 +201,7 @@ describe('portal-bridge', () => {
       const key = renderToContainer(container, 'content', undefined, gridEl);
 
       removeFromContainer(key);
-      expect(mockManager.removePortal).toHaveBeenCalledWith(key);
+      expect(mockManager.removePortal).toHaveBeenCalledWith(key, undefined);
     });
 
     it('should unmount fallback root when no manager', () => {
@@ -217,6 +217,18 @@ describe('portal-bridge', () => {
 
     it('should handle removing non-existent key gracefully', () => {
       expect(() => removeFromContainer('non-existent')).not.toThrow();
+    });
+
+    it('should pass sync option to portalManager.removePortal', () => {
+      const gridEl = createMockGrid();
+      const mockManager = createMockManager();
+      setPortalManager(gridEl, mockManager);
+
+      const container = document.createElement('div');
+      const key = renderToContainer(container, 'content', undefined, gridEl);
+
+      removeFromContainer(key, { sync: true });
+      expect(mockManager.removePortal).toHaveBeenCalledWith(key, true);
     });
   });
 
@@ -257,7 +269,7 @@ describe('portal-bridge', () => {
       renderToContainer(document.createElement('div'), 'b', undefined, grid2);
 
       removeFromContainer(key1);
-      expect(pm1.removePortal).toHaveBeenCalledWith(key1);
+      expect(pm1.removePortal).toHaveBeenCalledWith(key1, undefined);
       expect(pm2.removePortal).not.toHaveBeenCalled();
     });
 

--- a/libs/grid-react/src/lib/portal-bridge.ts
+++ b/libs/grid-react/src/lib/portal-bridge.ts
@@ -141,12 +141,16 @@ export function renderToContainer(
 
 /**
  * Remove a portal (or fallback root) by key.
+ *
+ * @param options.sync - When true, flush the removal synchronously so the
+ *   caller can safely clear the container DOM immediately after (e.g.,
+ *   tool panel accordion collapse sets `innerHTML = ''`).
  */
-export function removeFromContainer(key: string): void {
+export function removeFromContainer(key: string, options?: { sync?: boolean }): void {
   // Find the correct PortalManager via reverse lookup
   const grid = keyToGrid.get(key);
   const pm = grid ? portalManagers.get(grid) : undefined;
-  pm?.removePortal(key);
+  pm?.removePortal(key, options?.sync);
   keyToGrid.delete(key);
 
   cleanupFallbackRoot(key);

--- a/libs/grid-react/src/lib/portal-manager.spec.tsx
+++ b/libs/grid-react/src/lib/portal-manager.spec.tsx
@@ -127,6 +127,33 @@ describe('PortalManager', () => {
     unmount();
   });
 
+  it('should remove a portal synchronously when sync=true', async () => {
+    const { handle, unmount } = mountPortalManager();
+
+    const target = document.createElement('div');
+    document.body.appendChild(target);
+
+    await act(async () => {
+      handle.renderPortal('sync-key', target, React.createElement('span', null, 'Panel Content'));
+      await flushMicrotasks();
+    });
+    expect(target.textContent).toBe('Panel Content');
+
+    // Sync removal: React must fully unmount before innerHTML is cleared.
+    // This mirrors the tool panel accordion collapse flow where shell.ts
+    // calls cleanup() then contentArea.innerHTML = ''.
+    act(() => {
+      handle.removePortal('sync-key', true);
+    });
+    // Content is gone immediately (no microtask needed)
+    expect(target.textContent).toBe('');
+
+    // Clearing the container after sync removal must NOT throw
+    target.innerHTML = '';
+
+    unmount();
+  });
+
   it('should clear all portals', async () => {
     const { handle, unmount } = mountPortalManager();
 

--- a/libs/grid-react/src/lib/portal-manager.tsx
+++ b/libs/grid-react/src/lib/portal-manager.tsx
@@ -36,8 +36,15 @@ export interface PortalManagerHandle {
    */
   renderPortal(key: string, container: HTMLElement, element: ReactNode): void;
 
-  /** Remove a portal by key. */
-  removePortal(key: string): void;
+  /**
+   * Remove a portal by key.
+   * @param key unique key of the portal to remove
+   * @param sync - When true, flush the removal synchronously via `flushSync`
+   *   so the caller can safely mutate the container DOM immediately after.
+   *   Use this in cleanup callbacks that precede external DOM clearing
+   *   (e.g., tool panel accordion collapse sets `innerHTML = ''`).
+   */
+  removePortal(key: string, sync?: boolean): void;
 
   /** Remove all portals. */
   clear(): void;
@@ -106,9 +113,16 @@ export const PortalManager = forwardRef<PortalManagerHandle>(function PortalMana
         scheduleFlush();
       },
 
-      removePortal(key: string) {
+      removePortal(key: string, sync?: boolean) {
         if (portalsRef.current.delete(key)) {
-          scheduleFlush();
+          if (sync) {
+            // Synchronous removal — caller is about to clear the container
+            // DOM immediately (e.g., accordion collapse via innerHTML = '').
+            // React must fully unmount portal content before that happens.
+            flushSync(forceRender);
+          } else {
+            scheduleFlush();
+          }
         }
       },
 

--- a/libs/grid-react/src/lib/react-grid-adapter.ts
+++ b/libs/grid-react/src/lib/react-grid-adapter.ts
@@ -426,9 +426,10 @@ export class GridAdapter implements FrameworkAdapter {
       const portalKey = renderToContainer(container, renderFn(ctx), undefined, gridElement ?? undefined);
       this.trackPortal(portalKey, container, false);
 
-      // Return cleanup function
+      // Return cleanup function — sync removal ensures React fully unmounts
+      // portal content before the shell clears the container (innerHTML = '').
       return () => {
-        removeFromContainer(portalKey);
+        removeFromContainer(portalKey, { sync: true });
         this.untrackPortal(portalKey);
       };
     };

--- a/libs/grid-react/tsconfig.spec.json
+++ b/libs/grid-react/tsconfig.spec.json
@@ -11,5 +11,6 @@
     "src/**/*.test.tsx",
     "src/**/*.spec.tsx",
     "src/**/*.d.ts"
-  ]
+  ],
+  "references": [{ "path": "./tsconfig.lib.json" }]
 }


### PR DESCRIPTION
This pull request adds support for synchronous portal removal to ensure that React portal content is fully unmounted before the container DOM is cleared, addressing issues where immediate DOM mutations could cause errors. The main changes include updating the portal removal APIs to accept a `sync` option, updating all relevant call sites and tests, and ensuring that synchronous removal uses `flushSync` for immediate unmounting.
