### PR TITLE
feat(grid-react,grid-vue,grid-angular): adapter wrappers for shell-content APIs

### DIFF
--- a/.github/knowledge/adapters.md
+++ b/.github/knowledge/adapters.md
@@ -106,6 +106,11 @@ related: [grid-core, grid-features]
 
 - DECIDED: adapter cores (`{react,vue,angular}-grid-adapter.ts`, `react-column-config.ts`) MUST NOT runtime-reference feature behaviour (type-only imports OK). Runtime wiring lives in `features/<name>.ts` (React/Vue) or `features/<name>/src/` (Angular) secondary entries via registered bridges/hooks. Mirrors WC plugin discipline.
 
+## shell-content-wrappers (#352)
+
+- OWNS: React `Grid{Header,Toolbar}Content`, Vue `TbwGrid{Header,Toolbar}Content`, Angular `Grid{Header,Toolbar}Content` directives — wrap `registerHeaderContent`/`registerToolbarContent` (specs co-located). Vue uses built-in `<Teleport>` (slot child of `<TbwGrid>`); Angular uses `host.closest('tbw-grid')` (NOT `injectGrid()` — descendants).
+- INVARIANT: render-callback cleanup is a **no-op** AND `register*` MUST `await grid.ready?.()` then guard unmount-during-await (React `unmounted` / Vue `cancelled` / Angular `destroyed`); Angular extra: render MUST be idempotent (`createEmbeddedView` is not — skip when `viewRef.rootNodes[0]` still inside container, else destroy stale viewRef first). WHY: grid reuses SAME container by id across shell refreshes (`shell.ts` cleans → re-renders same node) — real teardown destroys child state; await leaks registration without flag.
+
 ### Bridge registries (append-only, populated by side-effect imports)
 
 | Registry                                                                | Module                                                                                   | Installed by                                                | Purpose                                                                                  |

--- a/apps/docs/src/content/docs/grid/angular/getting-started.mdx
+++ b/apps/docs/src/content/docs/grid/angular/getting-started.mdx
@@ -447,6 +447,39 @@ export class EmployeeGridComponent {
 
 **Inputs:** `id` (required), `title` (required), `icon`, `tooltip`, `order` (default `100`, lower = first).
 
+### Header & Toolbar Content
+
+Inject Angular components into the grid's shell header (left zone) or toolbar (right zone) via the [`GridHeaderContent`](/grid/angular/api/directives/GridHeaderContent/) and [`GridToolbarContent`](/grid/angular/api/directives/GridToolbarContent/) directives. These wrap the imperative `registerHeaderContent` / `registerToolbarContent` APIs and mount an `<ng-template>` so projected components retain full DI, change detection, and signal reactivity.
+
+```typescript
+import { Component, signal } from '@angular/core';
+import { Grid, GridHeaderContent, GridToolbarContent } from '@toolbox-web/grid-angular';
+
+@Component({
+  imports: [Grid, GridHeaderContent, GridToolbarContent, HeaderNavComponent, ToolbarNavComponent],
+  template: `
+    <tbw-grid [rows]="rows()" [gridConfig]="config()">
+      <tbw-grid-header-content id="calendar-nav" [order]="0">
+        <ng-template>
+          <app-header-nav [year]="year()" (yearChange)="onYearChange($event)" />
+        </ng-template>
+      </tbw-grid-header-content>
+      <tbw-grid-toolbar-content id="calendar-buttons" [order]="0">
+        <ng-template>
+          <app-toolbar-nav (previous)="prev()" (today)="today()" (next)="next()" />
+        </ng-template>
+      </tbw-grid-toolbar-content>
+    </tbw-grid>
+  `,
+})
+export class CalendarGridComponent {
+  year = signal(new Date().getFullYear());
+  onYearChange(year: number) { this.year.set(year); }
+}
+```
+
+**Inputs:** `id` (optional — auto-generated if omitted), `order` (default `100`, lower = first). Template bindings re-evaluate via Angular change detection without re-registering with the grid.
+
 ## Server-Side Data Loading
 
 The full data-source contract, sort/filter modes, prefetching, cancellation and live-update patterns are documented on the [Server-Side plugin](/grid/plugins/server-side/) page (it has runnable demos and an Angular tab in every example). The two Angular-specific points worth calling out here:

--- a/apps/docs/src/content/docs/grid/react/getting-started.mdx
+++ b/apps/docs/src/content/docs/grid/react/getting-started.mdx
@@ -232,6 +232,30 @@ function EmployeeGrid() {
 
 **Props:** `id` (required), `title` (required), `icon`, `tooltip`, `order` (default `100`, lower = first).
 
+## Header & Toolbar Content
+
+Inject framework content into the grid's shell header (left zone) or toolbar (right zone) via [`GridHeaderContent`](/grid/react/api/components/GridHeaderContent/) and [`GridToolbarContent`](/grid/react/api/components/GridToolbarContent/). These wrap the imperative `registerHeaderContent` / `registerToolbarContent` APIs so children render through React's normal reconciliation (state, context, hooks all work).
+
+```tsx
+import { DataGrid, GridHeaderContent, GridToolbarContent } from '@toolbox-web/grid-react';
+
+function CalendarGrid() {
+  const [year, setYear] = useState(new Date().getFullYear());
+  return (
+    <DataGrid rows={rows} columns={columns}>
+      <GridHeaderContent id="calendar-nav" order={0}>
+        <HeaderNav year={year} onYearChange={setYear} />
+      </GridHeaderContent>
+      <GridToolbarContent id="calendar-buttons" order={0}>
+        <ToolbarNav onPrev={prev} onToday={today} onNext={next} />
+      </GridToolbarContent>
+    </DataGrid>
+  );
+}
+```
+
+**Props:** `id` (optional — auto-generated if omitted), `order` (default `100`, lower = first). Children re-render in place when state changes without re-registering with the grid.
+
 ## Using the `useGrid` Hook
 
 The [`useGrid()`](/grid/react/api/hooks/useGrid/) hook provides programmatic access to the grid — see [`UseGridReturn`](/grid/react/api/types/UseGridReturn/) for the full return shape. It exposes core grid operations only; **feature-specific operations (export, selection, filtering, etc.) live on the dedicated feature hooks** (`useGridSelection`, `useGridExport`, ...) listed below.

--- a/apps/docs/src/content/docs/grid/vue/getting-started.mdx
+++ b/apps/docs/src/content/docs/grid/vue/getting-started.mdx
@@ -173,6 +173,31 @@ Each feature prop enables a specific plugin with simplified configuration:
 | `filterable` | `boolean` | Grid-wide filtering toggle (default: true). Requires FilteringPlugin. |
 | `selectable` | `boolean` | Grid-wide selection toggle (default: true). Requires SelectionPlugin. |
 
+## Header & Toolbar Content
+
+Inject Vue components into the grid's shell header (left zone) or toolbar (right zone) via `<TbwGridHeaderContent>` and `<TbwGridToolbarContent>`. These wrap the imperative `registerHeaderContent` / `registerToolbarContent` APIs using Vue's built-in `<Teleport>`, so slot content keeps full reactivity (props, refs, computed, slots, provide/inject).
+
+```html
+<script setup lang="ts">
+import { TbwGrid, TbwGridHeaderContent, TbwGridToolbarContent } from '@toolbox-web/grid-vue';
+import { ref } from 'vue';
+const year = ref(new Date().getFullYear());
+</script>
+
+<template>
+  <TbwGrid :rows="rows" :grid-config="config">
+    <TbwGridHeaderContent id="calendar-nav" :order="0">
+      <HeaderNav :year="year" @year-change="year = $event" />
+    </TbwGridHeaderContent>
+    <TbwGridToolbarContent id="calendar-buttons" :order="0">
+      <ToolbarNav @prev="prev" @today="today" @next="next" />
+    </TbwGridToolbarContent>
+  </TbwGrid>
+</template>
+```
+
+**Props:** `id` (optional — auto-generated if omitted), `order` (default `100`, lower = first). Slot content updates reactively without re-registering with the grid.
+
 ## Programmatic Grid Access
 
 Use the `useGrid` composable for programmatic control:

--- a/demos/angular/src/demos/calendar/calendar.component.html
+++ b/demos/angular/src/demos/calendar/calendar.component.html
@@ -1,6 +1,27 @@
 <div class="demo-container">
   <div class="calendar-demo">
     <tbw-grid #calendarGrid class="calendar-demo__grid" [rows]="rows()" [gridConfig]="gridConfig()">
+      <tbw-grid-header-content id="calendar-nav" [order]="0">
+        <ng-template>
+          <app-calendar-header-nav
+            class="cal-header"
+            [monthLabel]="monthLabel()"
+            [year]="year()"
+            [yearOptions]="yearOptions"
+            (yearChange)="onYearChange($event)"
+          />
+        </ng-template>
+      </tbw-grid-header-content>
+      <tbw-grid-toolbar-content id="calendar-nav-buttons" [order]="0">
+        <ng-template>
+          <app-calendar-toolbar-nav
+            class="cal-toolbar-nav"
+            (previous)="onPrevious()"
+            (today)="onToday()"
+            (next)="onNext()"
+          />
+        </ng-template>
+      </tbw-grid-toolbar-content>
       @for (field of weekdayFields; track field) {
         <tbw-grid-column [attr.field]="field">
           <app-calendar-day-cell *tbwRenderer="let day" [day]="day" />

--- a/demos/angular/src/demos/calendar/calendar.component.ts
+++ b/demos/angular/src/demos/calendar/calendar.component.ts
@@ -4,7 +4,6 @@ import {
   AfterViewInit,
   ChangeDetectionStrategy,
   Component,
-  ComponentRef,
   computed,
   ElementRef,
   inject,
@@ -23,8 +22,15 @@ import {
   WEEKDAY_HEADERS_FULL,
   WEEKDAY_HEADERS_MINI,
 } from '@demo/shared/calendar';
-import type { ColumnConfig, TbwGrid } from '@toolbox-web/grid';
-import { Grid, TbwGridColumn, TbwRenderer, type GridConfig } from '@toolbox-web/grid-angular';
+import type { ColumnConfig, DataGridElement } from '@toolbox-web/grid';
+import {
+  Grid,
+  GridHeaderContent,
+  GridToolbarContent,
+  TbwGridColumn,
+  TbwRenderer,
+  type GridConfig,
+} from '@toolbox-web/grid-angular';
 import { DayCellComponent } from './components/day-cell.component';
 import { EventDialogComponent } from './components/event-dialog.component';
 import { HeaderNavComponent } from './components/header-nav.component';
@@ -61,12 +67,22 @@ const ARROW_DAY_DELTA: Record<string, number> = {
   ArrowDown: 7,
 };
 
-type CalendarGridElement = TbwGrid<CalendarWeek>;
+type CalendarGridElement = DataGridElement<CalendarWeek>;
 type FocusTarget = { day: number } | { position: { rowIndex: number; colIndex: number } };
 
 @Component({
   selector: 'app-calendar',
-  imports: [Grid, TbwGridColumn, TbwRenderer, DayCellComponent, EventDialogComponent],
+  imports: [
+    Grid,
+    GridHeaderContent,
+    GridToolbarContent,
+    TbwGridColumn,
+    TbwRenderer,
+    DayCellComponent,
+    EventDialogComponent,
+    HeaderNavComponent,
+    ToolbarNavComponent,
+  ],
   templateUrl: './calendar.component.html',
   styleUrl: './calendar.component.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -81,19 +97,22 @@ export class CalendarComponent implements AfterViewInit, OnDestroy {
 
   private mountIntoContainer = inject(MountIntoContainer);
   private today = new Date();
-  private year = signal(this.today.getFullYear());
-  private month = signal(this.today.getMonth());
+  private yearSignal = signal(this.today.getFullYear());
+  private monthSignal = signal(this.today.getMonth());
   private userEvents = signal<ReadonlyMap<string, CalendarEvent[]>>(new Map());
   private rowHeight = signal(DEFAULT_ROW_HEIGHT_PX);
   private mountedShellComponents: Array<MountedComponent<unknown>> = [];
-  private headerComponentRef: ComponentRef<HeaderNavComponent> | null = null;
-  private shellSubscriptions: Array<{ unsubscribe: () => void }> = [];
   private heightObserver: ResizeObserver | null = null;
   private lastViewportHeight = 0;
   private lastMousedownCell: HTMLElement | null = null;
   private lastMousedownTime = 0;
 
-  readonly rows = computed(() => makeRows(this.year(), this.month(), this.userEvents()));
+  /** Exposed for the template-driven `<tbw-grid-header-content>` binding. */
+  readonly year = this.yearSignal.asReadonly();
+  /** Exposed for the template-driven `<tbw-grid-header-content>` binding. */
+  readonly monthLabel = computed(() => MONTH_NAMES[this.monthSignal()]);
+
+  readonly rows = computed(() => makeRows(this.year(), this.monthSignal(), this.userEvents()));
 
   readonly gridConfig = computed<GridConfig<CalendarWeek>>(() => ({
     fitMode: 'stretch',
@@ -126,7 +145,6 @@ export class CalendarComponent implements AfterViewInit, OnDestroy {
   ngAfterViewInit(): void {
     const grid = this.gridRef.nativeElement;
     grid.ready?.().then(() => {
-      this.mountShell(grid);
       grid.refreshShellHeader?.();
       const viewport = grid.querySelector<HTMLElement>('.rows-viewport');
       if (viewport) {
@@ -146,7 +164,6 @@ export class CalendarComponent implements AfterViewInit, OnDestroy {
     this.heightObserver?.disconnect();
     grid.removeEventListener('keydown', this.onKeydown, true);
     grid.removeEventListener('mousedown', this.onMousedown, true);
-    this.shellSubscriptions.forEach((subscription) => subscription.unsubscribe());
     this.mountedShellComponents.forEach((mounted) => mounted.destroy());
   }
 
@@ -178,60 +195,25 @@ export class CalendarComponent implements AfterViewInit, OnDestroy {
     };
   }
 
-  private mountShell(grid: CalendarGridElement): void {
-    grid.registerHeaderContent?.({
-      id: 'calendar-nav',
-      order: 0,
-      render: (container) => {
-        container.classList.add('cal-header');
-        const mounted = this.mountIntoContainer.mount(container, HeaderNavComponent);
-        this.mountedShellComponents.push(mounted);
-        const componentRef = mounted.componentRef as ComponentRef<HeaderNavComponent>;
-        this.headerComponentRef = componentRef;
-        this.updateHeader(componentRef);
-        const subscription = componentRef.instance.yearChange.subscribe((year) => {
-          this.year.set(year);
-          this.rerender();
-        });
-        this.shellSubscriptions.push(subscription);
-        return () => {
-          subscription.unsubscribe();
-          if (this.headerComponentRef === componentRef) {
-            this.headerComponentRef = null;
-          }
-          mounted.destroy();
-        };
-      },
-    });
-
-    grid.registerToolbarContent?.({
-      id: 'calendar-nav-buttons',
-      order: 0,
-      render: (container) => {
-        container.classList.add('cal-toolbar-nav');
-        const mounted = this.mountIntoContainer.mount(container, ToolbarNavComponent);
-        this.mountedShellComponents.push(mounted);
-        const toolbar = (mounted.componentRef as ComponentRef<ToolbarNavComponent>).instance;
-        const subscriptions = [
-          toolbar.previous.subscribe(() => this.shiftMonth(-1)),
-          toolbar.today.subscribe(() => this.goToday()),
-          toolbar.next.subscribe(() => this.shiftMonth(1)),
-        ];
-        this.shellSubscriptions.push(...subscriptions);
-        return () => {
-          subscriptions.forEach((subscription) => subscription.unsubscribe());
-          mounted.destroy();
-        };
-      },
-    });
+  /** Handler for the header-nav `<select>` year picker (template binding). */
+  onYearChange(year: number): void {
+    this.yearSignal.set(year);
+    this.rerender();
   }
 
-  private updateHeader(componentRef = this.headerComponentRef): void {
-    if (!componentRef) return;
-    componentRef.setInput('monthLabel', MONTH_NAMES[this.month()]);
-    componentRef.setInput('year', this.year());
-    componentRef.setInput('yearOptions', this.yearOptions);
-    componentRef.changeDetectorRef.detectChanges();
+  /** Handler for the toolbar-nav previous button (template binding). */
+  onPrevious(): void {
+    this.shiftMonth(-1);
+  }
+
+  /** Handler for the toolbar-nav today button (template binding). */
+  onToday(): void {
+    this.goToday();
+  }
+
+  /** Handler for the toolbar-nav next button (template binding). */
+  onNext(): void {
+    this.shiftMonth(1);
   }
 
   private legendContainer: HTMLElement | null = null;
@@ -249,29 +231,30 @@ export class CalendarComponent implements AfterViewInit, OnDestroy {
   }
 
   private shiftMonth(delta: number, focusTarget?: FocusTarget): void {
-    const date = new Date(this.year(), this.month() + delta, 1);
-    this.year.set(date.getFullYear());
-    this.month.set(date.getMonth());
+    const date = new Date(this.year(), this.monthSignal() + delta, 1);
+    this.yearSignal.set(date.getFullYear());
+    this.monthSignal.set(date.getMonth());
     this.rerender(focusTarget);
   }
 
   private goToday(): void {
     const today = new Date();
-    this.year.set(today.getFullYear());
-    this.month.set(today.getMonth());
+    this.yearSignal.set(today.getFullYear());
+    this.monthSignal.set(today.getMonth());
     this.rerender({ day: today.getDate() });
   }
 
   private rerender(focusTarget?: FocusTarget): void {
     const grid = this.gridRef.nativeElement;
-    this.updateHeader();
+    // Header re-renders automatically via signal-bound template inputs
+    // (monthLabel / year) on <app-calendar-header-nav>.
     this.applyRowHeight(grid);
 
     if (!focusTarget) return;
     const rows = this.rows();
     let position: { rowIndex: number; colIndex: number } | null = null;
     if ('day' in focusTarget) {
-      position = findDayPosition(rows, this.year(), this.month(), focusTarget.day);
+      position = findDayPosition(rows, this.year(), this.monthSignal(), focusTarget.day);
     } else {
       position = {
         rowIndex: Math.min(focusTarget.position.rowIndex, Math.max(rows.length - 1, 0)),
@@ -345,14 +328,14 @@ export class CalendarComponent implements AfterViewInit, OnDestroy {
     const targetMonth = target.getMonth();
     const targetDay = target.getDate();
 
-    if (targetYear === this.year() && targetMonth === this.month()) {
+    if (targetYear === this.year() && targetMonth === this.monthSignal()) {
       const position = findDayPosition(this.rows(), targetYear, targetMonth, targetDay);
       if (position) grid.focusCell?.(position.rowIndex, position.colIndex);
       return;
     }
 
-    this.year.set(targetYear);
-    this.month.set(targetMonth);
+    this.yearSignal.set(targetYear);
+    this.monthSignal.set(targetMonth);
     this.rerender({ day: targetDay });
   }
 

--- a/demos/react/src/demos/calendar/Calendar.tsx
+++ b/demos/react/src/demos/calendar/Calendar.tsx
@@ -11,7 +11,7 @@ import {
   WEEKDAY_HEADERS_FULL,
   WEEKDAY_HEADERS_MINI,
 } from '@demo/shared/calendar';
-import { DataGrid, useGrid, type GridConfig } from '@toolbox-web/grid-react';
+import { DataGrid, GridHeaderContent, GridToolbarContent, useGrid, type GridConfig } from '@toolbox-web/grid-react';
 import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react';
 
 import { DayCell } from './components/DayCell';
@@ -169,49 +169,6 @@ export function Calendar() {
   );
 
   useEffect(() => {
-    if (!grid.isReady) return;
-    const gridElement = grid.ref.current?.element;
-    if (!gridElement) return;
-
-    gridElement.registerHeaderContent?.({
-      id: 'calendar-nav',
-      order: 0,
-      render: (container: HTMLElement) =>
-        callbackRoot.renderInto(
-          container,
-          <HeaderNav
-            year={state.year}
-            month={state.month}
-            onYearChange={(year) => dispatch({ type: 'set-year', year })}
-          />,
-        ),
-    });
-    gridElement.registerToolbarContent?.({
-      id: 'calendar-nav-buttons',
-      order: 0,
-      render: (container: HTMLElement) =>
-        callbackRoot.renderInto(
-          container,
-          <ToolbarNav
-            onPrevious={() => dispatch({ type: 'shift-month', delta: -1 })}
-            onToday={() => {
-              const today = new Date();
-              pendingFocusRef.current = { day: today.getDate() };
-              dispatch({ type: 'today' });
-            }}
-            onNext={() => dispatch({ type: 'shift-month', delta: 1 })}
-          />,
-        ),
-    });
-    gridElement.refreshShellHeader?.();
-
-    return () => {
-      gridElement.unregisterHeaderContent?.('calendar-nav');
-      gridElement.unregisterToolbarContent?.('calendar-nav-buttons');
-    };
-  }, [callbackRoot, grid.isReady, grid.ref, state.month, state.year]);
-
-  useEffect(() => {
     const target = pendingFocusRef.current;
     if (!target || !grid.isReady) return;
     const gridElement = grid.ref.current?.element;
@@ -248,7 +205,26 @@ export function Calendar() {
     <div id="app">
       <div className="demo-container">
         <div className="calendar-demo">
-          <DataGrid ref={grid.ref} rows={rows} gridConfig={gridConfig} className="calendar-demo__grid" />
+          <DataGrid ref={grid.ref} rows={rows} gridConfig={gridConfig} className="calendar-demo__grid">
+            <GridHeaderContent id="calendar-nav" order={0}>
+              <HeaderNav
+                year={state.year}
+                month={state.month}
+                onYearChange={(year) => dispatch({ type: 'set-year', year })}
+              />
+            </GridHeaderContent>
+            <GridToolbarContent id="calendar-nav-buttons" order={0}>
+              <ToolbarNav
+                onPrevious={() => dispatch({ type: 'shift-month', delta: -1 })}
+                onToday={() => {
+                  const today = new Date();
+                  pendingFocusRef.current = { day: today.getDate() };
+                  dispatch({ type: 'today' });
+                }}
+                onNext={() => dispatch({ type: 'shift-month', delta: 1 })}
+              />
+            </GridToolbarContent>
+          </DataGrid>
           <EventDialog
             day={dialogDay}
             onCancel={() => setDialogDay(null)}

--- a/demos/vue/src/demos/calendar/Calendar.vue
+++ b/demos/vue/src/demos/calendar/Calendar.vue
@@ -1,6 +1,11 @@
 <script setup lang="ts">
 import type { DataGridElement, GridConfig } from '@toolbox-web/grid';
-import { TbwGrid as DataGrid, TbwGridColumn as GridColumn } from '@toolbox-web/grid-vue';
+import {
+  TbwGrid as DataGrid,
+  TbwGridColumn as GridColumn,
+  TbwGridHeaderContent,
+  TbwGridToolbarContent,
+} from '@toolbox-web/grid-vue';
 import '@toolbox-web/grid-vue/features/pinned-rows';
 import '@demo/shared/calendar/demo-styles.css';
 import {
@@ -70,7 +75,9 @@ const years = computed(() => {
 
 const rows = computed(() => makeRows(state, userEvents));
 
-const headerRoot = useGridCallbackRoot(HeaderNav, () => ({
+// Header/toolbar content is now rendered declaratively via
+// <TbwGridHeaderContent> / <TbwGridToolbarContent> in the template.
+const headerProps = computed(() => ({
   state,
   years: years.value,
   monthNames: MONTH_NAMES,
@@ -80,11 +87,11 @@ const headerRoot = useGridCallbackRoot(HeaderNav, () => ({
   },
 }));
 
-const toolbarRoot = useGridCallbackRoot(ToolbarNav, () => ({
+const toolbarProps = {
   onPrev: () => shiftMonth(-1),
   onToday: goToday,
   onNext: () => shiftMonth(1),
-}));
+};
 
 const legendRoot = useGridCallbackRoot(Legend, () => ({}));
 // Cache the legend element so the pinned-rows plugin can short-circuit DOM
@@ -194,9 +201,8 @@ onMounted(async () => {
   const grid = getGrid();
   if (!grid) return;
   await grid.ready?.();
-
-  grid.registerHeaderContent?.({ id: 'calendar-nav', order: 0, render: headerRoot.mount });
-  grid.registerToolbarContent?.({ id: 'calendar-nav-buttons', order: 0, render: toolbarRoot.mount });
+  // Header / toolbar registration is handled declaratively by the
+  // <TbwGridHeaderContent> and <TbwGridToolbarContent> wrappers below.
   grid.refreshShellHeader?.();
   // Vue's slot-mounted <TbwGridColumn> children don't trigger the grid's
   // column-template recompute on first mount; nudge it so layout uses the
@@ -228,12 +234,7 @@ watch(
 );
 
 onBeforeUnmount(() => {
-  const grid = getGrid();
-  grid?.unregisterHeaderContent?.('calendar-nav');
-  grid?.unregisterToolbarContent?.('calendar-nav-buttons');
   for (const cleanup of cleanups.splice(0)) cleanup();
-  headerRoot.cleanupAll();
-  toolbarRoot.cleanupAll();
   legendRoot.cleanupAll();
 });
 </script>
@@ -242,6 +243,12 @@ onBeforeUnmount(() => {
   <div class="demo-container">
     <div class="calendar-demo">
       <DataGrid ref="gridComponent" :rows="rows" :grid-config="gridConfig" class="calendar-demo__grid">
+        <TbwGridHeaderContent id="calendar-nav" :order="0">
+          <HeaderNav v-bind="headerProps" />
+        </TbwGridHeaderContent>
+        <TbwGridToolbarContent id="calendar-nav-buttons" :order="0">
+          <ToolbarNav v-bind="toolbarProps" />
+        </TbwGridToolbarContent>
         <GridColumn field="weekNumber" header="W" :width="44" :sortable="false" :resizable="false" />
         <GridColumn
           v-for="field in WEEKDAY_FIELDS"

--- a/libs/grid-angular/README.md
+++ b/libs/grid-angular/README.md
@@ -1117,16 +1117,18 @@ export class TextFilterComponent extends BaseFilterPanel {
 
 ### Exported Directives
 
-| Directive          | Selector                                             | Description                            |
-| ------------------ | ---------------------------------------------------- | -------------------------------------- |
-| `Grid`             | `tbw-grid`                                           | Main directive, auto-registers adapter |
-| `GridFormArray`    | `tbw-grid[formControlName]`, `tbw-grid[formControl]` | Reactive Forms integration             |
-| `TbwRenderer`      | `*tbwRenderer`                                       | Structural directive for cell views    |
-| `TbwEditor`        | `*tbwEditor`                                         | Structural directive for cell editors  |
-| `GridColumnView`   | `tbw-grid-column-view`                               | Nested directive for cell views        |
-| `GridColumnEditor` | `tbw-grid-column-editor`                             | Nested directive for cell editors      |
-| `GridDetailView`   | `tbw-grid-detail`                                    | Master-detail panel template           |
-| `GridToolPanel`    | `tbw-grid-tool-panel`                                | Custom sidebar panel                   |
+| Directive            | Selector                                             | Description                                     |
+| -------------------- | ---------------------------------------------------- | ----------------------------------------------- |
+| `Grid`               | `tbw-grid`                                           | Main directive, auto-registers adapter          |
+| `GridFormArray`      | `tbw-grid[formControlName]`, `tbw-grid[formControl]` | Reactive Forms integration                      |
+| `TbwRenderer`        | `*tbwRenderer`                                       | Structural directive for cell views             |
+| `TbwEditor`          | `*tbwEditor`                                         | Structural directive for cell editors           |
+| `GridColumnView`     | `tbw-grid-column-view`                               | Nested directive for cell views                 |
+| `GridColumnEditor`   | `tbw-grid-column-editor`                             | Nested directive for cell editors               |
+| `GridDetailView`     | `tbw-grid-detail`                                    | Master-detail panel template                    |
+| `GridToolPanel`      | `tbw-grid-tool-panel`                                | Custom sidebar panel                            |
+| `GridHeaderContent`  | `tbw-grid-header-content`                            | Inject Angular template into shell header zone  |
+| `GridToolbarContent` | `tbw-grid-toolbar-content`                           | Inject Angular template into shell toolbar zone |
 
 ### Base Classes
 

--- a/libs/grid-angular/project.json
+++ b/libs/grid-angular/project.json
@@ -26,7 +26,7 @@
       "executor": "nx:run-commands",
       "dependsOn": ["build"],
       "options": {
-        "command": "bun run tools/check-bundle-budget.ts dist/libs/grid-angular \"[{\\\"path\\\":\\\"fesm2022/toolbox-web-grid-angular.mjs\\\",\\\"maxSize\\\":266240}]\""
+        "command": "bun run tools/check-bundle-budget.ts dist/libs/grid-angular \"[{\\\"path\\\":\\\"fesm2022/toolbox-web-grid-angular.mjs\\\",\\\"maxSize\\\":276480}]\""
       }
     },
     "link-grid-dist": {

--- a/libs/grid-angular/src/index.ts
+++ b/libs/grid-angular/src/index.ts
@@ -91,6 +91,8 @@ export type { GridDetailContext } from './lib/directives/grid-detail-view.direct
 export { GridFormArray, getFormArrayContext } from './lib/directives/grid-form-array.directive';
 /** @deprecated Import from `@toolbox-web/grid-angular/features/editing` instead. Will be removed from the main entry in v2.0.0. */
 export type { FormArrayContext } from './lib/directives/grid-form-array.directive';
+export { GridHeaderContent } from './lib/directives/grid-header-content.directive';
+export type { GridHeaderContentContext } from './lib/directives/grid-header-content.directive';
 export { TbwGridHeader } from './lib/directives/grid-header.directive';
 /** @deprecated Import from `@toolbox-web/grid-angular/features/editing` instead. Will be removed from the main entry in v2.0.0. */
 export { GridLazyForm, getLazyFormContext } from './lib/directives/grid-lazy-form.directive';
@@ -101,6 +103,8 @@ export type { GridResponsiveCardContext } from './lib/directives/grid-responsive
 export { TbwGridToolButtons } from './lib/directives/grid-tool-buttons.directive';
 export { GridToolPanel } from './lib/directives/grid-tool-panel.directive';
 export type { GridToolPanelContext } from './lib/directives/grid-tool-panel.directive';
+export { GridToolbarContent } from './lib/directives/grid-toolbar-content.directive';
+export type { GridToolbarContentContext } from './lib/directives/grid-toolbar-content.directive';
 export { Grid } from './lib/directives/grid.directive';
 export type { CellCommitEvent, RowCommitEvent } from './lib/directives/grid.directive';
 

--- a/libs/grid-angular/src/lib/directives/grid-header-content.directive.ts
+++ b/libs/grid-angular/src/lib/directives/grid-header-content.directive.ts
@@ -1,0 +1,180 @@
+import {
+  afterNextRender,
+  contentChild,
+  DestroyRef,
+  Directive,
+  effect,
+  ElementRef,
+  EmbeddedViewRef,
+  inject,
+  input,
+  TemplateRef,
+  ViewContainerRef,
+} from '@angular/core';
+import type { DataGridElement, HeaderContentDefinition } from '@toolbox-web/grid';
+
+/**
+ * Context object passed to the header content template.
+ * @since 1.7.0
+ */
+export interface GridHeaderContentContext {
+  /** The grid element (implicit binding for `let-grid`). */
+  $implicit: DataGridElement;
+  /** The grid element. */
+  grid: DataGridElement;
+}
+
+let autoIdCounter = 0;
+
+/**
+ * Declarative wrapper around the grid's imperative
+ * {@link DataGridElement.registerHeaderContent} API.
+ *
+ * Captures an `<ng-template>` and mounts it as an Angular embedded view into
+ * the slot the grid provides for header content. Must be a child of
+ * `<tbw-grid>`.
+ *
+ * ## Usage
+ *
+ * ```html
+ * <tbw-grid [rows]="rows" [gridConfig]="config">
+ *   <tbw-grid-header-content id="calendar-nav" [order]="0">
+ *     <ng-template let-grid>
+ *       <app-header-nav [year]="year()" (yearChange)="setYear($event)" />
+ *     </ng-template>
+ *   </tbw-grid-header-content>
+ * </tbw-grid>
+ * ```
+ *
+ * @category Directive
+ * @since 1.7.0
+ */
+@Directive({ selector: 'tbw-grid-header-content', standalone: true })
+export class GridHeaderContent {
+  private elementRef = inject(ElementRef<HTMLElement>);
+  private viewContainerRef = inject(ViewContainerRef);
+  private destroyRef = inject(DestroyRef);
+
+  /** Unique identifier for this header content entry. Optional — defaults to a stable generated id. */
+  id = input<string | undefined>(undefined);
+
+  /** Render order priority. Lower values appear first. @default 100 */
+  order = input<number>(100);
+
+  /** The template to mount into the grid's header content slot. */
+  template = contentChild(TemplateRef<GridHeaderContentContext>);
+
+  private viewRef: EmbeddedViewRef<GridHeaderContentContext> | null = null;
+  private registeredId: string | null = null;
+  private resolvedId = `tbw-header-content-${++autoIdCounter}`;
+  private destroyed = false;
+
+  constructor() {
+    afterNextRender(() => {
+      void this.register();
+    });
+
+    this.destroyRef.onDestroy(() => {
+      this.destroyed = true;
+      this.unregister();
+    });
+
+    // Re-register when id or order changes after mount.
+    effect(() => {
+      const nextId = this.id() ?? this.resolvedId;
+      const nextOrder = this.order();
+      if (this.registeredId && this.registeredId !== nextId) {
+        this.unregister();
+        void this.register();
+        return;
+      }
+      if (this.registeredId && nextOrder !== this.lastOrder) {
+        this.unregister();
+        void this.register();
+      }
+      this.lastOrder = nextOrder;
+    });
+  }
+
+  private lastOrder: number | undefined;
+
+  private async register(): Promise<void> {
+    const grid = this.findGrid();
+    if (!grid) return;
+    try {
+      await grid.ready?.();
+    } catch {
+      return;
+    }
+    if (this.destroyed) return;
+
+    const template = this.template();
+    const id = this.id() ?? this.resolvedId;
+    const order = this.order();
+
+    const def: HeaderContentDefinition = {
+      id,
+      order,
+      render: (container) => {
+        if (!template) return undefined;
+        // Sticky container: the shell may re-invoke `render` with the SAME
+        // container across refreshes. If our embedded view is still attached
+        // inside it, the previous render is live and this is a refresh — do
+        // nothing (no-op cleanup preserves child state).
+        const firstNode = this.viewRef?.rootNodes[0] as Node | undefined;
+        if (this.viewRef && firstNode && container.contains(firstNode)) {
+          return () => {
+            /* intentionally empty */
+          };
+        }
+        // Fresh container (first render or container was replaced) — destroy
+        // any stale view, then build a new one.
+        if (this.viewRef) {
+          this.viewRef.destroy();
+          this.viewRef = null;
+        }
+        this.viewRef = this.viewContainerRef.createEmbeddedView(template, {
+          $implicit: grid,
+          grid,
+        });
+        this.viewRef.detectChanges();
+        for (const node of this.viewRef.rootNodes as Node[]) {
+          container.appendChild(node);
+        }
+        // No-op cleanup: the grid may call this between re-renders before
+        // invoking `render` again with the SAME container. Tearing the view
+        // down here would destroy any internal state in the projected
+        // template on every shell refresh. Teardown happens in `unregister`
+        // (component destroy / id / order change).
+        return () => {
+          /* intentionally empty */
+        };
+      },
+    };
+    grid.registerHeaderContent?.(def);
+    this.registeredId = id;
+  }
+
+  private unregister(): void {
+    const grid = this.findGrid();
+    if (grid && this.registeredId) {
+      grid.unregisterHeaderContent?.(this.registeredId);
+    }
+    this.registeredId = null;
+    if (this.viewRef) {
+      this.viewRef.destroy();
+      this.viewRef = null;
+    }
+  }
+
+  private findGrid(): DataGridElement | null {
+    const host = this.elementRef.nativeElement;
+    const grid = host.closest('tbw-grid') as DataGridElement | null;
+    return grid;
+  }
+
+  /** Type guard for template context inference. */
+  static ngTemplateContextGuard(_dir: GridHeaderContent, ctx: unknown): ctx is GridHeaderContentContext {
+    return true;
+  }
+}

--- a/libs/grid-angular/src/lib/directives/grid-shell-content.spec.ts
+++ b/libs/grid-angular/src/lib/directives/grid-shell-content.spec.ts
@@ -1,53 +1,329 @@
 /**
- * Smoke tests for GridHeaderContent and GridToolbarContent directives.
+ * Behavior tests for GridHeaderContent and GridToolbarContent directives.
  *
- * Follows the package convention of avoiding Angular TestBed and instead
- * verifying class structure + the public guards/hooks that don't require a
- * full DI bootstrap. Full integration behavior is exercised by the calendar
- * demo and adapter conformance tests.
+ * Follows the package convention established by `grid-form-array.directive.spec.ts`:
+ * mock Angular's DI primitives (`inject`, `effect`, `afterNextRender`, `input`,
+ * `contentChild`) so we can instantiate the real directive class directly and
+ * exercise its registration/unregistration contract against a fake grid.
  *
  * @vitest-environment happy-dom
  */
 import '@angular/compiler';
-import { describe, expect, it } from 'vitest';
+import type { DataGridElement, HeaderContentDefinition, ToolbarContentDefinition } from '@toolbox-web/grid';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// --- Mock Angular DI primitives --------------------------------------------
+let mockInjectResolver: (token: unknown) => unknown = () => undefined;
+const afterNextRenderCallbacks: Array<() => void> = [];
+let destroyCallback: (() => void) | null = null;
+
+vi.mock('@angular/core', async () => {
+  const actual = await vi.importActual<typeof import('@angular/core')>('@angular/core');
+  function inputFn(initial?: unknown): { (): unknown } & { __setValue: (v: unknown) => void } {
+    let value: unknown = initial;
+    const fn = (() => value) as { (): unknown } & { __setValue: (v: unknown) => void };
+    fn.__setValue = (v: unknown) => {
+      value = v;
+    };
+    return fn;
+  }
+  const input = Object.assign(inputFn, { required: () => inputFn() });
+  return {
+    ...actual,
+    inject: (token: unknown) => mockInjectResolver(token),
+    effect: () => ({ destroy: () => undefined }),
+    afterNextRender: (cb: () => void) => {
+      afterNextRenderCallbacks.push(cb);
+    },
+    input,
+    contentChild: inputFn,
+  };
+});
+
+// Imports must come AFTER vi.mock above.
+import { DestroyRef, ElementRef, TemplateRef, ViewContainerRef, type EmbeddedViewRef } from '@angular/core';
 import { GridHeaderContent } from './grid-header-content.directive';
 import { GridToolbarContent } from './grid-toolbar-content.directive';
 
-describe('GridHeaderContent', () => {
-  it('is importable and defined', () => {
-    expect(GridHeaderContent).toBeDefined();
-    expect(typeof GridHeaderContent).toBe('function');
-  });
+// ---------------------------------------------------------------------------
+// Harness helpers
+// ---------------------------------------------------------------------------
 
-  it('has a static ngTemplateContextGuard that always returns true', () => {
-    expect(typeof GridHeaderContent.ngTemplateContextGuard).toBe('function');
+interface MockGrid extends HTMLElement {
+  ready: ReturnType<typeof vi.fn>;
+  registerHeaderContent: ReturnType<typeof vi.fn>;
+  unregisterHeaderContent: ReturnType<typeof vi.fn>;
+  registerToolbarContent: ReturnType<typeof vi.fn>;
+  unregisterToolbarContent: ReturnType<typeof vi.fn>;
+  headerDefs: HeaderContentDefinition[];
+  toolbarDefs: ToolbarContentDefinition[];
+}
+
+function createMockGrid(): MockGrid {
+  const grid = document.createElement('tbw-grid') as unknown as MockGrid;
+  grid.headerDefs = [];
+  grid.toolbarDefs = [];
+  grid.ready = vi.fn(() => Promise.resolve());
+  grid.registerHeaderContent = vi.fn((def: HeaderContentDefinition) => {
+    grid.headerDefs.push(def);
+  });
+  grid.unregisterHeaderContent = vi.fn();
+  grid.registerToolbarContent = vi.fn((def: ToolbarContentDefinition) => {
+    grid.toolbarDefs.push(def);
+  });
+  grid.unregisterToolbarContent = vi.fn();
+  return grid;
+}
+
+function createMockViewContainerRef(): ViewContainerRef {
+  return {
+    createEmbeddedView: vi.fn(<T>(_tpl: TemplateRef<T>, ctx: T) => {
+      const node = document.createElement('span');
+      node.textContent = 'tpl';
+      const view: Partial<EmbeddedViewRef<T>> = {
+        rootNodes: [node],
+        context: ctx,
+        detectChanges: vi.fn(),
+        destroy: vi.fn(),
+      };
+      return view as EmbeddedViewRef<T>;
+    }),
+  } as unknown as ViewContainerRef;
+}
+
+interface BuiltHeader {
+  directive: GridHeaderContent;
+  grid: MockGrid;
+  host: HTMLElement;
+  runAfterNextRender: () => Promise<void>;
+  triggerDestroy: () => void;
+}
+
+function buildHeader(opts: { withGrid?: boolean; id?: string; order?: number } = {}): BuiltHeader {
+  afterNextRenderCallbacks.length = 0;
+  destroyCallback = null;
+  const grid = createMockGrid();
+  const host = document.createElement('tbw-grid-header-content');
+  if (opts.withGrid !== false) {
+    grid.appendChild(host);
+    document.body.appendChild(grid);
+  } else {
+    document.body.appendChild(host);
+  }
+  const elementRef = { nativeElement: host } as ElementRef<HTMLElement>;
+  const viewContainerRef = createMockViewContainerRef();
+  const destroyRef = {
+    onDestroy: (cb: () => void) => {
+      destroyCallback = cb;
+      return () => undefined;
+    },
+  } as unknown as DestroyRef;
+  mockInjectResolver = (token: unknown) => {
+    if (token === ElementRef) return elementRef;
+    if (token === ViewContainerRef) return viewContainerRef;
+    if (token === DestroyRef) return destroyRef;
+    return undefined;
+  };
+  const directive = new GridHeaderContent();
+  if (opts.id !== undefined) {
+    (directive.id as unknown as { __setValue: (v: unknown) => void }).__setValue(opts.id);
+  }
+  if (opts.order !== undefined) {
+    (directive.order as unknown as { __setValue: (v: unknown) => void }).__setValue(opts.order);
+  }
+  const template = {} as TemplateRef<unknown>;
+  (directive.template as unknown as { __setValue: (v: unknown) => void }).__setValue(template);
+  return {
+    directive,
+    grid,
+    host,
+    runAfterNextRender: async () => {
+      const cbs = afterNextRenderCallbacks.splice(0);
+      for (const cb of cbs) cb();
+      await Promise.resolve();
+      await Promise.resolve();
+    },
+    triggerDestroy: () => destroyCallback?.(),
+  };
+}
+
+interface BuiltToolbar {
+  directive: GridToolbarContent;
+  grid: MockGrid;
+  host: HTMLElement;
+  runAfterNextRender: () => Promise<void>;
+  triggerDestroy: () => void;
+}
+
+function buildToolbar(opts: { id?: string; order?: number } = {}): BuiltToolbar {
+  afterNextRenderCallbacks.length = 0;
+  destroyCallback = null;
+  const grid = createMockGrid();
+  const host = document.createElement('tbw-grid-toolbar-content');
+  grid.appendChild(host);
+  document.body.appendChild(grid);
+  const elementRef = { nativeElement: host } as ElementRef<HTMLElement>;
+  const viewContainerRef = createMockViewContainerRef();
+  const destroyRef = {
+    onDestroy: (cb: () => void) => {
+      destroyCallback = cb;
+      return () => undefined;
+    },
+  } as unknown as DestroyRef;
+  mockInjectResolver = (token: unknown) => {
+    if (token === ElementRef) return elementRef;
+    if (token === ViewContainerRef) return viewContainerRef;
+    if (token === DestroyRef) return destroyRef;
+    return undefined;
+  };
+  const directive = new GridToolbarContent();
+  if (opts.id !== undefined) {
+    (directive.id as unknown as { __setValue: (v: unknown) => void }).__setValue(opts.id);
+  }
+  if (opts.order !== undefined) {
+    (directive.order as unknown as { __setValue: (v: unknown) => void }).__setValue(opts.order);
+  }
+  const template = {} as TemplateRef<unknown>;
+  (directive.template as unknown as { __setValue: (v: unknown) => void }).__setValue(template);
+  return {
+    directive,
+    grid,
+    host,
+    runAfterNextRender: async () => {
+      const cbs = afterNextRenderCallbacks.splice(0);
+      for (const cb of cbs) cb();
+      await Promise.resolve();
+      await Promise.resolve();
+    },
+    triggerDestroy: () => destroyCallback?.(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  afterNextRenderCallbacks.length = 0;
+  destroyCallback = null;
+});
+
+describe('GridHeaderContent (real directive)', () => {
+  it('static ngTemplateContextGuard returns true', () => {
     expect(GridHeaderContent.ngTemplateContextGuard({} as GridHeaderContent, {})).toBe(true);
   });
 
-  it('exposes register / unregister / findGrid as instance prototype methods', () => {
-    // These are private TS-wise but exist on the prototype at runtime.
-    const proto = GridHeaderContent.prototype as Record<string, unknown>;
-    expect(typeof proto['register']).toBe('function');
-    expect(typeof proto['unregister']).toBe('function');
-    expect(typeof proto['findGrid']).toBe('function');
+  it('awaits grid.ready then calls registerHeaderContent with id + order', async () => {
+    const built = buildHeader({ id: 'hdr-1', order: 7 });
+    await built.runAfterNextRender();
+    expect(built.grid.ready).toHaveBeenCalled();
+    expect(built.grid.registerHeaderContent).toHaveBeenCalledTimes(1);
+    expect(built.grid.headerDefs[0].id).toBe('hdr-1');
+    expect(built.grid.headerDefs[0].order).toBe(7);
+  });
+
+  it('falls back to a generated id when none is provided', async () => {
+    const built = buildHeader({ order: 0 });
+    await built.runAfterNextRender();
+    expect(built.grid.headerDefs[0].id).toMatch(/^tbw-header-content-\d+$/);
+  });
+
+  it('does nothing when no parent <tbw-grid> is in the DOM', async () => {
+    const built = buildHeader({ withGrid: false, id: 'no-parent' });
+    await built.runAfterNextRender();
+    expect(built.grid.registerHeaderContent).not.toHaveBeenCalled();
+  });
+
+  it('skips registration if destroyed before ready() resolves', async () => {
+    const built = buildHeader({ id: 'hdr-race' });
+    let resolveReady: () => void = () => undefined;
+    built.grid.ready.mockReturnValue(
+      new Promise<void>((res) => {
+        resolveReady = res;
+      }),
+    );
+    const cbs = afterNextRenderCallbacks.splice(0);
+    for (const cb of cbs) cb();
+    built.triggerDestroy();
+    resolveReady();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(built.grid.registerHeaderContent).not.toHaveBeenCalled();
+  });
+
+  it('render callback is idempotent for sticky-container reuse', async () => {
+    const built = buildHeader({ id: 'hdr-idem' });
+    await built.runAfterNextRender();
+    const def = built.grid.headerDefs[0];
+    const container = document.createElement('div');
+    def.render(container);
+    expect(container.children.length).toBe(1);
+    // Re-render with SAME container — must NOT duplicate.
+    def.render(container);
+    expect(container.children.length).toBe(1);
+  });
+
+  it('unregister is called on directive destroy', async () => {
+    const built = buildHeader({ id: 'hdr-destroy' });
+    await built.runAfterNextRender();
+    built.triggerDestroy();
+    expect(built.grid.unregisterHeaderContent).toHaveBeenCalledWith('hdr-destroy');
   });
 });
 
-describe('GridToolbarContent', () => {
-  it('is importable and defined', () => {
-    expect(GridToolbarContent).toBeDefined();
-    expect(typeof GridToolbarContent).toBe('function');
-  });
-
-  it('has a static ngTemplateContextGuard that always returns true', () => {
-    expect(typeof GridToolbarContent.ngTemplateContextGuard).toBe('function');
+describe('GridToolbarContent (real directive)', () => {
+  it('static ngTemplateContextGuard returns true', () => {
     expect(GridToolbarContent.ngTemplateContextGuard({} as GridToolbarContent, {})).toBe(true);
   });
 
-  it('exposes register / unregister / findGrid as instance prototype methods', () => {
-    const proto = GridToolbarContent.prototype as Record<string, unknown>;
-    expect(typeof proto['register']).toBe('function');
-    expect(typeof proto['unregister']).toBe('function');
-    expect(typeof proto['findGrid']).toBe('function');
+  it('awaits grid.ready then calls registerToolbarContent with id + order', async () => {
+    const built = buildToolbar({ id: 'tb-1', order: 3 });
+    await built.runAfterNextRender();
+    expect(built.grid.ready).toHaveBeenCalled();
+    expect(built.grid.registerToolbarContent).toHaveBeenCalledTimes(1);
+    expect(built.grid.toolbarDefs[0].id).toBe('tb-1');
+    expect(built.grid.toolbarDefs[0].order).toBe(3);
+  });
+
+  it('falls back to a generated id when none is provided', async () => {
+    const built = buildToolbar({ order: 0 });
+    await built.runAfterNextRender();
+    expect(built.grid.toolbarDefs[0].id).toMatch(/^tbw-toolbar-content-\d+$/);
+  });
+
+  it('skips registration if destroyed before ready() resolves', async () => {
+    const built = buildToolbar({ id: 'tb-race' });
+    let resolveReady: () => void = () => undefined;
+    built.grid.ready.mockReturnValue(
+      new Promise<void>((res) => {
+        resolveReady = res;
+      }),
+    );
+    const cbs = afterNextRenderCallbacks.splice(0);
+    for (const cb of cbs) cb();
+    built.triggerDestroy();
+    resolveReady();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(built.grid.registerToolbarContent).not.toHaveBeenCalled();
+  });
+
+  it('render callback is idempotent for sticky-container reuse', async () => {
+    const built = buildToolbar({ id: 'tb-idem' });
+    await built.runAfterNextRender();
+    const def = built.grid.toolbarDefs[0];
+    const container = document.createElement('div');
+    def.render(container);
+    expect(container.children.length).toBe(1);
+    def.render(container);
+    expect(container.children.length).toBe(1);
+  });
+
+  it('unregister is called on directive destroy', async () => {
+    const built = buildToolbar({ id: 'tb-destroy' });
+    await built.runAfterNextRender();
+    built.triggerDestroy();
+    expect(built.grid.unregisterToolbarContent).toHaveBeenCalledWith('tb-destroy');
   });
 });

--- a/libs/grid-angular/src/lib/directives/grid-shell-content.spec.ts
+++ b/libs/grid-angular/src/lib/directives/grid-shell-content.spec.ts
@@ -1,0 +1,53 @@
+/**
+ * Smoke tests for GridHeaderContent and GridToolbarContent directives.
+ *
+ * Follows the package convention of avoiding Angular TestBed and instead
+ * verifying class structure + the public guards/hooks that don't require a
+ * full DI bootstrap. Full integration behavior is exercised by the calendar
+ * demo and adapter conformance tests.
+ *
+ * @vitest-environment happy-dom
+ */
+import '@angular/compiler';
+import { describe, expect, it } from 'vitest';
+import { GridHeaderContent } from './grid-header-content.directive';
+import { GridToolbarContent } from './grid-toolbar-content.directive';
+
+describe('GridHeaderContent', () => {
+  it('is importable and defined', () => {
+    expect(GridHeaderContent).toBeDefined();
+    expect(typeof GridHeaderContent).toBe('function');
+  });
+
+  it('has a static ngTemplateContextGuard that always returns true', () => {
+    expect(typeof GridHeaderContent.ngTemplateContextGuard).toBe('function');
+    expect(GridHeaderContent.ngTemplateContextGuard({} as GridHeaderContent, {})).toBe(true);
+  });
+
+  it('exposes register / unregister / findGrid as instance prototype methods', () => {
+    // These are private TS-wise but exist on the prototype at runtime.
+    const proto = GridHeaderContent.prototype as Record<string, unknown>;
+    expect(typeof proto['register']).toBe('function');
+    expect(typeof proto['unregister']).toBe('function');
+    expect(typeof proto['findGrid']).toBe('function');
+  });
+});
+
+describe('GridToolbarContent', () => {
+  it('is importable and defined', () => {
+    expect(GridToolbarContent).toBeDefined();
+    expect(typeof GridToolbarContent).toBe('function');
+  });
+
+  it('has a static ngTemplateContextGuard that always returns true', () => {
+    expect(typeof GridToolbarContent.ngTemplateContextGuard).toBe('function');
+    expect(GridToolbarContent.ngTemplateContextGuard({} as GridToolbarContent, {})).toBe(true);
+  });
+
+  it('exposes register / unregister / findGrid as instance prototype methods', () => {
+    const proto = GridToolbarContent.prototype as Record<string, unknown>;
+    expect(typeof proto['register']).toBe('function');
+    expect(typeof proto['unregister']).toBe('function');
+    expect(typeof proto['findGrid']).toBe('function');
+  });
+});

--- a/libs/grid-angular/src/lib/directives/grid-shell-content.spec.ts
+++ b/libs/grid-angular/src/lib/directives/grid-shell-content.spec.ts
@@ -9,12 +9,13 @@
  * @vitest-environment happy-dom
  */
 import '@angular/compiler';
-import type { DataGridElement, HeaderContentDefinition, ToolbarContentDefinition } from '@toolbox-web/grid';
+import type { HeaderContentDefinition, ToolbarContentDefinition } from '@toolbox-web/grid';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 // --- Mock Angular DI primitives --------------------------------------------
 let mockInjectResolver: (token: unknown) => unknown = () => undefined;
 const afterNextRenderCallbacks: Array<() => void> = [];
+const effectCallbacks: Array<() => void> = [];
 let destroyCallback: (() => void) | null = null;
 
 vi.mock('@angular/core', async () => {
@@ -31,7 +32,12 @@ vi.mock('@angular/core', async () => {
   return {
     ...actual,
     inject: (token: unknown) => mockInjectResolver(token),
-    effect: () => ({ destroy: () => undefined }),
+    effect: (cb: () => void) => {
+      effectCallbacks.push(cb);
+      // Run once immediately (Angular effects run synchronously after construction).
+      cb();
+      return { destroy: () => undefined };
+    },
     afterNextRender: (cb: () => void) => {
       afterNextRenderCallbacks.push(cb);
     },
@@ -101,6 +107,7 @@ interface BuiltHeader {
 
 function buildHeader(opts: { withGrid?: boolean; id?: string; order?: number } = {}): BuiltHeader {
   afterNextRenderCallbacks.length = 0;
+  effectCallbacks.length = 0;
   destroyCallback = null;
   const grid = createMockGrid();
   const host = document.createElement('tbw-grid-header-content');
@@ -157,6 +164,7 @@ interface BuiltToolbar {
 
 function buildToolbar(opts: { id?: string; order?: number } = {}): BuiltToolbar {
   afterNextRenderCallbacks.length = 0;
+  effectCallbacks.length = 0;
   destroyCallback = null;
   const grid = createMockGrid();
   const host = document.createElement('tbw-grid-toolbar-content');
@@ -203,9 +211,14 @@ function buildToolbar(opts: { id?: string; order?: number } = {}): BuiltToolbar 
 // Tests
 // ---------------------------------------------------------------------------
 
+function runEffects(): void {
+  for (const cb of effectCallbacks) cb();
+}
+
 afterEach(() => {
   document.body.innerHTML = '';
   afterNextRenderCallbacks.length = 0;
+  effectCallbacks.length = 0;
   destroyCallback = null;
 });
 
@@ -270,6 +283,42 @@ describe('GridHeaderContent (real directive)', () => {
     built.triggerDestroy();
     expect(built.grid.unregisterHeaderContent).toHaveBeenCalledWith('hdr-destroy');
   });
+
+  it('re-registers when id changes after initial registration', async () => {
+    const built = buildHeader({ id: 'hdr-a', order: 1 });
+    await built.runAfterNextRender();
+    expect(built.grid.headerDefs.map((d) => d.id)).toEqual(['hdr-a']);
+    (built.directive.id as unknown as { __setValue: (v: unknown) => void }).__setValue('hdr-b');
+    runEffects();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(built.grid.unregisterHeaderContent).toHaveBeenCalledWith('hdr-a');
+    expect(built.grid.headerDefs.map((d) => d.id)).toEqual(['hdr-a', 'hdr-b']);
+  });
+
+  it('re-registers when order changes after initial registration', async () => {
+    const built = buildHeader({ id: 'hdr-ord', order: 1 });
+    await built.runAfterNextRender();
+    (built.directive.order as unknown as { __setValue: (v: unknown) => void }).__setValue(9);
+    runEffects();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(built.grid.unregisterHeaderContent).toHaveBeenCalledWith('hdr-ord');
+    expect(built.grid.headerDefs.map((d) => d.order)).toEqual([1, 9]);
+  });
+
+  it('skips registration when grid.ready() rejects', async () => {
+    const built = buildHeader({ id: 'hdr-rej' });
+    built.grid.ready.mockRejectedValue(new Error('boom'));
+    await built.runAfterNextRender();
+    expect(built.grid.registerHeaderContent).not.toHaveBeenCalled();
+  });
+
+  it('destroy without prior registration does not call unregister', () => {
+    const built = buildHeader({ id: 'hdr-noreg' });
+    built.triggerDestroy();
+    expect(built.grid.unregisterHeaderContent).not.toHaveBeenCalled();
+  });
 });
 
 describe('GridToolbarContent (real directive)', () => {
@@ -325,5 +374,34 @@ describe('GridToolbarContent (real directive)', () => {
     await built.runAfterNextRender();
     built.triggerDestroy();
     expect(built.grid.unregisterToolbarContent).toHaveBeenCalledWith('tb-destroy');
+  });
+
+  it('re-registers when id changes after initial registration', async () => {
+    const built = buildToolbar({ id: 'tb-a', order: 1 });
+    await built.runAfterNextRender();
+    (built.directive.id as unknown as { __setValue: (v: unknown) => void }).__setValue('tb-b');
+    runEffects();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(built.grid.unregisterToolbarContent).toHaveBeenCalledWith('tb-a');
+    expect(built.grid.toolbarDefs.map((d) => d.id)).toEqual(['tb-a', 'tb-b']);
+  });
+
+  it('re-registers when order changes after initial registration', async () => {
+    const built = buildToolbar({ id: 'tb-ord', order: 1 });
+    await built.runAfterNextRender();
+    (built.directive.order as unknown as { __setValue: (v: unknown) => void }).__setValue(9);
+    runEffects();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(built.grid.unregisterToolbarContent).toHaveBeenCalledWith('tb-ord');
+    expect(built.grid.toolbarDefs.map((d) => d.order)).toEqual([1, 9]);
+  });
+
+  it('skips registration when grid.ready() rejects', async () => {
+    const built = buildToolbar({ id: 'tb-rej' });
+    built.grid.ready.mockRejectedValue(new Error('boom'));
+    await built.runAfterNextRender();
+    expect(built.grid.registerToolbarContent).not.toHaveBeenCalled();
   });
 });

--- a/libs/grid-angular/src/lib/directives/grid-toolbar-content.directive.ts
+++ b/libs/grid-angular/src/lib/directives/grid-toolbar-content.directive.ts
@@ -1,0 +1,166 @@
+import {
+  afterNextRender,
+  contentChild,
+  DestroyRef,
+  Directive,
+  effect,
+  ElementRef,
+  EmbeddedViewRef,
+  inject,
+  input,
+  TemplateRef,
+  ViewContainerRef,
+} from '@angular/core';
+import type { DataGridElement, ToolbarContentDefinition } from '@toolbox-web/grid';
+
+/**
+ * Context object passed to the toolbar content template.
+ * @since 1.7.0
+ */
+export interface GridToolbarContentContext {
+  /** The grid element (implicit binding for `let-grid`). */
+  $implicit: DataGridElement;
+  /** The grid element. */
+  grid: DataGridElement;
+}
+
+let autoIdCounter = 0;
+
+/**
+ * Declarative wrapper around the grid's imperative
+ * {@link DataGridElement.registerToolbarContent} API.
+ *
+ * Captures an `<ng-template>` and mounts it as an Angular embedded view into
+ * the slot the grid provides for toolbar content. Must be a child of
+ * `<tbw-grid>`.
+ *
+ * Prefer this over `<tbw-grid-tool-buttons>` (light DOM) when you need
+ * Angular template bindings to component state. Use the light-DOM form for
+ * static markup that should be moved verbatim into the toolbar.
+ *
+ * ## Usage
+ *
+ * ```html
+ * <tbw-grid [rows]="rows" [gridConfig]="config">
+ *   <tbw-grid-toolbar-content id="calendar-nav" [order]="0">
+ *     <ng-template let-grid>
+ *       <app-toolbar-nav (prev)="prev()" (today)="today()" (next)="next()" />
+ *     </ng-template>
+ *   </tbw-grid-toolbar-content>
+ * </tbw-grid>
+ * ```
+ *
+ * @category Directive
+ * @since 1.7.0
+ */
+@Directive({ selector: 'tbw-grid-toolbar-content', standalone: true })
+export class GridToolbarContent {
+  private elementRef = inject(ElementRef<HTMLElement>);
+  private viewContainerRef = inject(ViewContainerRef);
+  private destroyRef = inject(DestroyRef);
+
+  id = input<string | undefined>(undefined);
+  order = input<number>(100);
+  template = contentChild(TemplateRef<GridToolbarContentContext>);
+
+  private viewRef: EmbeddedViewRef<GridToolbarContentContext> | null = null;
+  private registeredId: string | null = null;
+  private resolvedId = `tbw-toolbar-content-${++autoIdCounter}`;
+  private lastOrder: number | undefined;
+  private destroyed = false;
+
+  constructor() {
+    afterNextRender(() => {
+      void this.register();
+    });
+
+    this.destroyRef.onDestroy(() => {
+      this.destroyed = true;
+      this.unregister();
+    });
+
+    effect(() => {
+      const nextId = this.id() ?? this.resolvedId;
+      const nextOrder = this.order();
+      if (this.registeredId && this.registeredId !== nextId) {
+        this.unregister();
+        void this.register();
+        return;
+      }
+      if (this.registeredId && nextOrder !== this.lastOrder) {
+        this.unregister();
+        void this.register();
+      }
+      this.lastOrder = nextOrder;
+    });
+  }
+
+  private async register(): Promise<void> {
+    const grid = this.findGrid();
+    if (!grid) return;
+    try {
+      await grid.ready?.();
+    } catch {
+      return;
+    }
+    if (this.destroyed) return;
+
+    const template = this.template();
+    const id = this.id() ?? this.resolvedId;
+    const order = this.order();
+
+    const def: ToolbarContentDefinition = {
+      id,
+      order,
+      render: (container) => {
+        if (!template) return undefined;
+        // Sticky container: see grid-header-content.directive.ts for rationale.
+        const firstNode = this.viewRef?.rootNodes[0] as Node | undefined;
+        if (this.viewRef && firstNode && container.contains(firstNode)) {
+          return () => {
+            /* intentionally empty */
+          };
+        }
+        if (this.viewRef) {
+          this.viewRef.destroy();
+          this.viewRef = null;
+        }
+        this.viewRef = this.viewContainerRef.createEmbeddedView(template, {
+          $implicit: grid,
+          grid,
+        });
+        this.viewRef.detectChanges();
+        for (const node of this.viewRef.rootNodes as Node[]) {
+          container.appendChild(node);
+        }
+        // No-op cleanup — see comment in grid-header-content.directive.ts.
+        return () => {
+          /* intentionally empty */
+        };
+      },
+    };
+    grid.registerToolbarContent?.(def);
+    this.registeredId = id;
+  }
+
+  private unregister(): void {
+    const grid = this.findGrid();
+    if (grid && this.registeredId) {
+      grid.unregisterToolbarContent?.(this.registeredId);
+    }
+    this.registeredId = null;
+    if (this.viewRef) {
+      this.viewRef.destroy();
+      this.viewRef = null;
+    }
+  }
+
+  private findGrid(): DataGridElement | null {
+    const host = this.elementRef.nativeElement;
+    return host.closest('tbw-grid') as DataGridElement | null;
+  }
+
+  static ngTemplateContextGuard(_dir: GridToolbarContent, ctx: unknown): ctx is GridToolbarContentContext {
+    return true;
+  }
+}

--- a/libs/grid-angular/src/lib/directives/index.ts
+++ b/libs/grid-angular/src/lib/directives/index.ts
@@ -2,11 +2,12 @@ export { GridColumnEditor } from './grid-column-editor.directive';
 export { GridColumnView } from './grid-column-view.directive';
 export { TbwGridColumn } from './grid-column.directive';
 export { GridDetailView } from './grid-detail-view.directive';
-export { getFormArrayContext, GridFormArray } from './grid-form-array.directive';
+export { GridFormArray, getFormArrayContext } from './grid-form-array.directive';
 export type { FormArrayContext } from './grid-form-array.directive';
+export { GridHeaderContent, type GridHeaderContentContext } from './grid-header-content.directive';
 export { TbwGridHeader } from './grid-header.directive';
 export { GridResponsiveCard } from './grid-responsive-card.directive';
 export { TbwGridToolButtons } from './grid-tool-buttons.directive';
 export { GridToolPanel } from './grid-tool-panel.directive';
+export { GridToolbarContent, type GridToolbarContentContext } from './grid-toolbar-content.directive';
 export { Grid } from './grid.directive';
-

--- a/libs/grid-react/README.md
+++ b/libs/grid-react/README.md
@@ -640,16 +640,18 @@ Inject custom CSS into the grid:
 
 ### Exported Components
 
-| Component          | Description                                 |
-| ------------------ | ------------------------------------------- |
-| `DataGrid`         | Main grid component wrapper                 |
-| `GridColumn`       | Declarative column with render props        |
-| `GridDetailPanel`  | Master-detail expandable panel              |
-| `GridToolPanel`    | Custom sidebar panel                        |
-| `GridToolButtons`  | Toolbar button container                    |
-| `GridProvider`     | Combined provider for icons & type defaults |
-| `GridTypeProvider` | App-level type defaults context             |
-| `GridIconProvider` | App-level icon overrides context            |
+| Component            | Description                                  |
+| -------------------- | -------------------------------------------- |
+| `DataGrid`           | Main grid component wrapper                  |
+| `GridColumn`         | Declarative column with render props         |
+| `GridDetailPanel`    | Master-detail expandable panel               |
+| `GridToolPanel`      | Custom sidebar panel                         |
+| `GridHeaderContent`  | Inject React content into shell header zone  |
+| `GridToolbarContent` | Inject React content into shell toolbar zone |
+| `GridToolButtons`    | Toolbar button container                     |
+| `GridProvider`       | Combined provider for icons & type defaults  |
+| `GridTypeProvider`   | App-level type defaults context              |
+| `GridIconProvider`   | App-level icon overrides context             |
 
 ### Exported Hooks
 

--- a/libs/grid-react/src/index.ts
+++ b/libs/grid-react/src/index.ts
@@ -24,6 +24,7 @@ export type { DataGridProps, DataGridRef } from './lib/data-grid';
 export { GridColumn } from './lib/grid-column';
 export type { GridColumnProps } from './lib/grid-column';
 export { GridDetailPanel, type DetailPanelContext, type GridDetailPanelProps } from './lib/grid-detail-panel';
+export { GridHeaderContent, type GridHeaderContentProps } from './lib/grid-header-content';
 export {
   GridResponsiveCard,
   type GridResponsiveCardProps,
@@ -31,6 +32,7 @@ export {
 } from './lib/grid-responsive-card';
 export { GridToolButtons, type GridToolButtonsProps } from './lib/grid-tool-button';
 export { GridToolPanel, type GridToolPanelProps, type ToolPanelContext } from './lib/grid-tool-panel';
+export { GridToolbarContent, type GridToolbarContentProps } from './lib/grid-toolbar-content';
 
 // Feature props types for declarative plugin configuration
 export type {

--- a/libs/grid-react/src/lib/grid-header-content.tsx
+++ b/libs/grid-react/src/lib/grid-header-content.tsx
@@ -1,0 +1,110 @@
+import type { HeaderContentDefinition } from '@toolbox-web/grid';
+import { useContext, useEffect, useId, useRef, useState, type ReactNode } from 'react';
+import { GridElementContext } from './grid-element-context';
+import { removeFromContainer, renderToContainer } from './portal-bridge';
+
+/**
+ * Props for {@link GridHeaderContent}.
+ * @since 1.8.0
+ */
+export interface GridHeaderContentProps {
+  /**
+   * Unique identifier for this header content entry.
+   * Defaults to a stable React-generated id (`tbw-header-content-:rN:`).
+   */
+  id?: string;
+  /**
+   * Render order priority. Lower values appear first.
+   * @default 100
+   */
+  order?: number;
+  /** React content to project into the grid shell header content area. */
+  children: ReactNode;
+}
+
+/**
+ * Declarative wrapper around the grid's imperative
+ * {@link DataGridElement.registerHeaderContent} API.
+ *
+ * Mounts its children into the slot the grid provides for header content while
+ * keeping them inside the React tree (so context, Suspense, error boundaries,
+ * portals, etc. all work). Must be a descendant of `<DataGrid>`.
+ *
+ * @example
+ * ```tsx
+ * <DataGrid gridConfig={config}>
+ *   <GridHeaderContent id="calendar-nav" order={0}>
+ *     <HeaderNav year={year} onYearChange={setYear} />
+ *   </GridHeaderContent>
+ * </DataGrid>
+ * ```
+ *
+ * @category Component
+ * @since 1.8.0
+ */
+export function GridHeaderContent({ id: idProp, order = 100, children }: GridHeaderContentProps): null {
+  const generatedId = useId();
+  const id = idProp ?? `tbw-header-content-${generatedId}`;
+
+  const gridRef = useContext(GridElementContext);
+
+  // The container the grid hands us during render. State (not ref) so that the
+  // portal-update effect below re-runs when it becomes available or changes.
+  const [container, setContainer] = useState<HTMLElement | null>(null);
+  const portalKeyRef = useRef<string | null>(null);
+
+  // Register / unregister with the grid. Re-runs when identity-ish props change.
+  useEffect(() => {
+    const grid = gridRef?.current;
+    if (!grid) return;
+    const portalKeyForCleanup = portalKeyRef;
+
+    let unmounted = false;
+
+    void (async () => {
+      try {
+        await grid.ready?.();
+      } catch {
+        return;
+      }
+      if (unmounted) return;
+
+      const def: HeaderContentDefinition = {
+        id,
+        order,
+        render: (el) => {
+          setContainer(el);
+          // No-op cleanup: the grid calls this between re-renders before
+          // invoking `render` again with the SAME container (sticky by id).
+          // Tearing the portal down here would destroy any internal state in
+          // the children on every shell refresh. Teardown happens in the
+          // outer effect's cleanup below (on unmount / id / order change).
+          return () => {
+            /* intentionally empty */
+          };
+        },
+      };
+      grid.registerHeaderContent?.(def);
+    })();
+
+    return () => {
+      unmounted = true;
+      grid.unregisterHeaderContent?.(id);
+      if (portalKeyForCleanup.current) {
+        removeFromContainer(portalKeyForCleanup.current, { sync: true });
+        portalKeyForCleanup.current = null;
+      }
+      setContainer(null);
+    };
+  }, [gridRef, id, order]);
+
+  // Mount / update the portal whenever children or the container change.
+  // Reuses the same portal key so React reconciles in place.
+  useEffect(() => {
+    if (!container) return;
+    const grid = gridRef?.current ?? undefined;
+    portalKeyRef.current = renderToContainer(container, children, portalKeyRef.current ?? undefined, grid);
+  }, [children, container, gridRef]);
+
+  return null;
+}

--- a/libs/grid-react/src/lib/grid-shell-content.spec.tsx
+++ b/libs/grid-react/src/lib/grid-shell-content.spec.tsx
@@ -1,0 +1,230 @@
+/**
+ * Tests for GridHeaderContent and GridToolbarContent wrappers.
+ *
+ * Verifies the imperative bridging contract:
+ * - Calls `register*Content` with id + order after grid.ready resolves
+ * - Mounts children into the container the grid hands to the render callback
+ * - Forwards children updates without re-registering
+ * - Calls `unregister*Content` on unmount
+ *
+ * @vitest-environment happy-dom
+ */
+import type { DataGridElement, HeaderContentDefinition, ToolbarContentDefinition } from '@toolbox-web/grid';
+import { act, createRef, useState, type RefObject } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { GridElementContext } from './grid-element-context';
+import { GridHeaderContent } from './grid-header-content';
+import { GridToolbarContent } from './grid-toolbar-content';
+
+beforeAll(() => {
+  (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+interface MockGrid extends Partial<DataGridElement> {
+  ready: () => Promise<void>;
+  registerHeaderContent: (def: HeaderContentDefinition) => void;
+  unregisterHeaderContent: (id: string) => void;
+  registerToolbarContent: (def: ToolbarContentDefinition) => void;
+  unregisterToolbarContent: (id: string) => void;
+}
+
+interface Harness {
+  grid: MockGrid;
+  gridRef: RefObject<DataGridElement | null>;
+  container: HTMLElement;
+  /** Container the grid would hand to the render callback. */
+  slot: HTMLElement;
+  root: Root;
+  headerDefs: HeaderContentDefinition[];
+  toolbarDefs: ToolbarContentDefinition[];
+  unregisteredHeader: string[];
+  unregisteredToolbar: string[];
+}
+
+function setupHarness(): Harness {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const slot = document.createElement('div');
+  const headerDefs: HeaderContentDefinition[] = [];
+  const toolbarDefs: ToolbarContentDefinition[] = [];
+  const unregisteredHeader: string[] = [];
+  const unregisteredToolbar: string[] = [];
+  const grid: MockGrid = {
+    ready: vi.fn().mockResolvedValue(undefined),
+    registerHeaderContent: vi.fn((def: HeaderContentDefinition) => {
+      headerDefs.push(def);
+      def.render(slot);
+    }),
+    unregisterHeaderContent: vi.fn((id: string) => {
+      unregisteredHeader.push(id);
+    }),
+    registerToolbarContent: vi.fn((def: ToolbarContentDefinition) => {
+      toolbarDefs.push(def);
+      def.render(slot);
+    }),
+    unregisterToolbarContent: vi.fn((id: string) => {
+      unregisteredToolbar.push(id);
+    }),
+  };
+  const gridRef: RefObject<DataGridElement | null> = createRef<DataGridElement | null>();
+  (gridRef as { current: DataGridElement | null }).current = grid as unknown as DataGridElement;
+  const root = createRoot(container);
+  return { grid, gridRef, container, slot, root, headerDefs, toolbarDefs, unregisteredHeader, unregisteredToolbar };
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// GridHeaderContent
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('GridHeaderContent', () => {
+  it('registers with the grid using provided id + order after ready resolves', async () => {
+    const h = setupHarness();
+    await act(async () => {
+      h.root.render(
+        <GridElementContext.Provider value={h.gridRef}>
+          <GridHeaderContent id="hdr-1" order={5}>
+            <span data-testid="hdr">hello</span>
+          </GridHeaderContent>
+        </GridElementContext.Provider>,
+      );
+    });
+    expect(h.grid.ready).toHaveBeenCalled();
+    expect(h.headerDefs).toHaveLength(1);
+    expect(h.headerDefs[0]).toMatchObject({ id: 'hdr-1', order: 5 });
+  });
+
+  it('mounts children into the grid-provided container via portal', async () => {
+    const h = setupHarness();
+    await act(async () => {
+      h.root.render(
+        <GridElementContext.Provider value={h.gridRef}>
+          <GridHeaderContent id="hdr-2">
+            <span data-testid="hdr">hello</span>
+          </GridHeaderContent>
+        </GridElementContext.Provider>,
+      );
+    });
+    // PortalManager flushes via microtask + rAF.
+    await act(async () => {
+      await new Promise((r) => queueMicrotask(r));
+      await new Promise((r) => requestAnimationFrame(() => r(undefined)));
+    });
+    expect(h.slot.querySelector('[data-testid="hdr"]')?.textContent).toBe('hello');
+  });
+
+  it('forwards children updates without re-registering', async () => {
+    const h = setupHarness();
+    let setLabel!: (s: string) => void;
+    function Harness() {
+      const [label, _set] = useState('first');
+      setLabel = _set;
+      return (
+        <GridElementContext.Provider value={h.gridRef}>
+          <GridHeaderContent id="hdr-3">
+            <span data-testid="hdr">{label}</span>
+          </GridHeaderContent>
+        </GridElementContext.Provider>
+      );
+    }
+    await act(async () => {
+      h.root.render(<Harness />);
+    });
+    await act(async () => {
+      setLabel('second');
+      await new Promise((r) => queueMicrotask(r));
+      await new Promise((r) => requestAnimationFrame(() => r(undefined)));
+    });
+    expect(h.grid.registerHeaderContent).toHaveBeenCalledTimes(1);
+    expect(h.slot.querySelector('[data-testid="hdr"]')?.textContent).toBe('second');
+  });
+
+  it('unregisters on unmount', async () => {
+    const h = setupHarness();
+    await act(async () => {
+      h.root.render(
+        <GridElementContext.Provider value={h.gridRef}>
+          <GridHeaderContent id="hdr-4">
+            <span>x</span>
+          </GridHeaderContent>
+        </GridElementContext.Provider>,
+      );
+    });
+    await act(async () => {
+      h.root.unmount();
+    });
+    expect(h.unregisteredHeader).toContain('hdr-4');
+  });
+
+  it('renders null host (no extra DOM)', async () => {
+    const h = setupHarness();
+    await act(async () => {
+      h.root.render(
+        <GridElementContext.Provider value={h.gridRef}>
+          <GridHeaderContent id="hdr-5">
+            <span>x</span>
+          </GridHeaderContent>
+        </GridElementContext.Provider>,
+      );
+    });
+    // The wrapper itself returns null; only the portal's container (h.slot) holds DOM.
+    // h.container is the React root container, which holds nothing visible.
+    expect(h.container.children.length).toBe(0);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// GridToolbarContent
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('GridToolbarContent', () => {
+  it('registers with the grid using provided id + order', async () => {
+    const h = setupHarness();
+    await act(async () => {
+      h.root.render(
+        <GridElementContext.Provider value={h.gridRef}>
+          <GridToolbarContent id="tb-1" order={3}>
+            <button>go</button>
+          </GridToolbarContent>
+        </GridElementContext.Provider>,
+      );
+    });
+    expect(h.toolbarDefs).toHaveLength(1);
+    expect(h.toolbarDefs[0]).toMatchObject({ id: 'tb-1', order: 3 });
+  });
+
+  it('unregisters on unmount', async () => {
+    const h = setupHarness();
+    await act(async () => {
+      h.root.render(
+        <GridElementContext.Provider value={h.gridRef}>
+          <GridToolbarContent id="tb-2">
+            <button>go</button>
+          </GridToolbarContent>
+        </GridElementContext.Provider>,
+      );
+    });
+    await act(async () => {
+      h.root.unmount();
+    });
+    expect(h.unregisteredToolbar).toContain('tb-2');
+  });
+
+  it('renders nothing when not inside a grid context', async () => {
+    const h = setupHarness();
+    await act(async () => {
+      h.root.render(
+        <GridElementContext.Provider value={null}>
+          <GridToolbarContent id="tb-3">
+            <button>x</button>
+          </GridToolbarContent>
+        </GridElementContext.Provider>,
+      );
+    });
+    expect(h.toolbarDefs).toHaveLength(0);
+  });
+});

--- a/libs/grid-react/src/lib/grid-shell-content.spec.tsx
+++ b/libs/grid-react/src/lib/grid-shell-content.spec.tsx
@@ -68,7 +68,7 @@ function setupHarness(): Harness {
     }),
   };
   const gridRef: RefObject<DataGridElement | null> = createRef<DataGridElement | null>();
-  (gridRef as { current: DataGridElement | null }).current = grid as unknown as DataGridElement;
+  (gridRef as { current: DataGridElement | null }).current = grid as DataGridElement;
   const root = createRoot(container);
   return { grid, gridRef, container, slot, root, headerDefs, toolbarDefs, unregisteredHeader, unregisteredToolbar };
 }

--- a/libs/grid-react/src/lib/grid-toolbar-content.tsx
+++ b/libs/grid-react/src/lib/grid-toolbar-content.tsx
@@ -1,0 +1,104 @@
+import type { ToolbarContentDefinition } from '@toolbox-web/grid';
+import { useContext, useEffect, useId, useRef, useState, type ReactNode } from 'react';
+import { GridElementContext } from './grid-element-context';
+import { removeFromContainer, renderToContainer } from './portal-bridge';
+
+/**
+ * Props for {@link GridToolbarContent}.
+ * @since 1.8.0
+ */
+export interface GridToolbarContentProps {
+  /**
+   * Unique identifier for this toolbar content entry.
+   * Defaults to a stable React-generated id (`tbw-toolbar-content-:rN:`).
+   */
+  id?: string;
+  /**
+   * Render order priority. Lower values appear first.
+   * @default 100
+   */
+  order?: number;
+  /** React content to project into the grid shell toolbar. */
+  children: ReactNode;
+}
+
+/**
+ * Declarative wrapper around the grid's imperative
+ * {@link DataGridElement.registerToolbarContent} API.
+ *
+ * Mounts its children into the slot the grid provides for toolbar content while
+ * keeping them inside the React tree. Must be a descendant of `<DataGrid>`.
+ *
+ * Prefer this over `<tbw-grid-tool-buttons>` (light DOM) when you need
+ * reactive props or callbacks bound to React state. Use the light-DOM form
+ * for static markup that should be moved verbatim into the toolbar.
+ *
+ * @example
+ * ```tsx
+ * <DataGrid gridConfig={config}>
+ *   <GridToolbarContent id="calendar-nav" order={0}>
+ *     <ToolbarNav onPrev={prev} onToday={today} onNext={next} />
+ *   </GridToolbarContent>
+ * </DataGrid>
+ * ```
+ *
+ * @category Component
+ * @since 1.8.0
+ */
+export function GridToolbarContent({ id: idProp, order = 100, children }: GridToolbarContentProps): null {
+  const generatedId = useId();
+  const id = idProp ?? `tbw-toolbar-content-${generatedId}`;
+
+  const gridRef = useContext(GridElementContext);
+
+  const [container, setContainer] = useState<HTMLElement | null>(null);
+  const portalKeyRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const grid = gridRef?.current;
+    if (!grid) return;
+    const portalKeyForCleanup = portalKeyRef;
+
+    let unmounted = false;
+
+    void (async () => {
+      try {
+        await grid.ready?.();
+      } catch {
+        return;
+      }
+      if (unmounted) return;
+
+      const def: ToolbarContentDefinition = {
+        id,
+        order,
+        render: (el) => {
+          setContainer(el);
+          // No-op cleanup — see comment in grid-header-content.tsx.
+          return () => {
+            /* intentionally empty */
+          };
+        },
+      };
+      grid.registerToolbarContent?.(def);
+    })();
+
+    return () => {
+      unmounted = true;
+      grid.unregisterToolbarContent?.(id);
+      if (portalKeyForCleanup.current) {
+        removeFromContainer(portalKeyForCleanup.current, { sync: true });
+        portalKeyForCleanup.current = null;
+      }
+      setContainer(null);
+    };
+  }, [gridRef, id, order]);
+
+  useEffect(() => {
+    if (!container) return;
+    const grid = gridRef?.current ?? undefined;
+    portalKeyRef.current = renderToContainer(container, children, portalKeyRef.current ?? undefined, grid);
+  }, [children, container, gridRef]);
+
+  return null;
+}

--- a/libs/grid-vue/README.md
+++ b/libs/grid-vue/README.md
@@ -561,17 +561,19 @@ const props = defineProps<{
 
 ### Components
 
-| Component               | Description                   |
-| ----------------------- | ----------------------------- |
-| `TbwGrid`               | Main grid wrapper component   |
-| `TbwGridColumn`         | Declarative column definition |
-| `TbwGridDetailPanel`    | Master-detail row content     |
-| `TbwGridToolPanel`      | Custom sidebar panel          |
-| `TbwGridToolButtons`    | Toolbar button container      |
-| `TbwGridResponsiveCard` | Mobile card layout template   |
-| `GridTypeProvider`      | App-wide type defaults        |
-| `GridIconProvider`      | App-wide icon overrides       |
-| `GridProvider`          | Combined type + icon provider |
+| Component               | Description                                    |
+| ----------------------- | ---------------------------------------------- |
+| `TbwGrid`               | Main grid wrapper component                    |
+| `TbwGridColumn`         | Declarative column definition                  |
+| `TbwGridDetailPanel`    | Master-detail row content                      |
+| `TbwGridToolPanel`      | Custom sidebar panel                           |
+| `TbwGridHeaderContent`  | Inject Vue content into the shell header zone  |
+| `TbwGridToolbarContent` | Inject Vue content into the shell toolbar zone |
+| `TbwGridToolButtons`    | Toolbar button container                       |
+| `TbwGridResponsiveCard` | Mobile card layout template                    |
+| `GridTypeProvider`      | App-wide type defaults                         |
+| `GridIconProvider`      | App-wide icon overrides                        |
+| `GridProvider`          | Combined type + icon provider                  |
 
 ### Composables
 

--- a/libs/grid-vue/src/index.ts
+++ b/libs/grid-vue/src/index.ts
@@ -44,7 +44,9 @@
 export { default as TbwGrid } from './lib/TbwGrid.vue';
 export { default as TbwGridColumn } from './lib/TbwGridColumn.vue';
 export { default as TbwGridDetailPanel } from './lib/TbwGridDetailPanel.vue';
+export { default as TbwGridHeaderContent } from './lib/TbwGridHeaderContent.vue';
 export { default as TbwGridResponsiveCard } from './lib/TbwGridResponsiveCard.vue';
+export { default as TbwGridToolbarContent } from './lib/TbwGridToolbarContent.vue';
 export { default as TbwGridToolButtons } from './lib/TbwGridToolButtons.vue';
 export { default as TbwGridToolPanel } from './lib/TbwGridToolPanel.vue';
 

--- a/libs/grid-vue/src/lib/TbwGridHeaderContent.vue
+++ b/libs/grid-vue/src/lib/TbwGridHeaderContent.vue
@@ -1,0 +1,124 @@
+<script setup lang="ts">
+/**
+ * Declarative wrapper around the grid's imperative
+ * `registerHeaderContent` API. Mounts its default slot into the slot the
+ * grid provides for header content via Vue's built-in `<Teleport>`, so
+ * provide/inject, Pinia, Vue Router, and all other context flow through.
+ * Must be a descendant of `<TbwGrid>`.
+ *
+ * @example
+ * ```vue
+ * <TbwGrid :rows="rows" :gridConfig="config">
+ *   <TbwGridHeaderContent id="calendar-nav" :order="0">
+ *     <HeaderNav :year="year" @year-change="setYear" />
+ *   </TbwGridHeaderContent>
+ * </TbwGrid>
+ * ```
+ *
+ * @since 1.9.0
+ */
+import type { DataGridElement, HeaderContentDefinition } from '@toolbox-web/grid';
+import { inject, onBeforeUnmount, onMounted, ref, useId, watch } from 'vue';
+import { GRID_ELEMENT_KEY } from './use-grid';
+
+/**
+ * Props for `TbwGridHeaderContent`.
+ */
+const props = withDefaults(
+  defineProps<{
+    /**
+     * Unique identifier for this header content entry.
+     * Defaults to a stable Vue-generated id.
+     */
+    id?: string;
+    /**
+     * Render order priority. Lower values appear first.
+     * @default 100
+     */
+    order?: number;
+  }>(),
+  { order: 100 },
+);
+
+defineSlots<{
+  /** Default slot — content rendered into the grid shell header content area. */
+  default?: () => unknown;
+}>();
+
+const fallbackId = useId();
+const contentId = ref<string>(props.id ?? `tbw-header-content-${fallbackId}`);
+watch(
+  () => props.id,
+  (next) => {
+    contentId.value = next ?? `tbw-header-content-${fallbackId}`;
+  },
+);
+
+const gridRef = inject(GRID_ELEMENT_KEY, ref<DataGridElement | null>(null));
+
+/** Container slot the grid hands us during render. Used as the Teleport target. */
+const container = ref<HTMLElement | null>(null);
+
+let registeredId: string | null = null;
+let cancelled = false;
+
+async function registerWith(grid: DataGridElement, id: string, order: number): Promise<void> {
+  try {
+    await grid.ready?.();
+  } catch {
+    return;
+  }
+  if (cancelled) return;
+  const def: HeaderContentDefinition = {
+    id,
+    order,
+    render: (el) => {
+      container.value = el;
+      // No-op cleanup: the grid calls this between re-renders before invoking
+      // `render` again with the SAME container (sticky by id). Tearing the
+      // Teleport down here would destroy any internal state in the slot
+      // contents on every shell refresh. We teardown only on component
+      // unmount via `onBeforeUnmount` -> `unregisterHeaderContent`.
+      return () => {
+        /* intentionally empty */
+      };
+    },
+  };
+  grid.registerHeaderContent?.(def);
+  registeredId = id;
+}
+
+function unregister(grid: DataGridElement | null, id: string | null): void {
+  if (!grid || !id) return;
+  grid.unregisterHeaderContent?.(id);
+}
+
+onMounted(() => {
+  const grid = gridRef.value;
+  if (!grid) return;
+  void registerWith(grid, contentId.value, props.order);
+});
+
+// Re-register if id or order changes after mount.
+watch([contentId, () => props.order], async ([nextId, nextOrder], [prevId, prevOrder]) => {
+  const grid = gridRef.value;
+  if (!grid) return;
+  if (registeredId && (nextId !== prevId || nextOrder !== prevOrder)) {
+    unregister(grid, registeredId);
+    registeredId = null;
+    await registerWith(grid, nextId, nextOrder);
+  }
+});
+
+onBeforeUnmount(() => {
+  cancelled = true;
+  unregister(gridRef.value, registeredId);
+  registeredId = null;
+});
+</script>
+
+<template>
+  <Teleport v-if="container" :to="container">
+    <slot />
+  </Teleport>
+</template>

--- a/libs/grid-vue/src/lib/TbwGridHeaderContent.vue
+++ b/libs/grid-vue/src/lib/TbwGridHeaderContent.vue
@@ -62,13 +62,19 @@ const container = ref<HTMLElement | null>(null);
 let registeredId: string | null = null;
 let cancelled = false;
 
-async function registerWith(grid: DataGridElement, id: string, order: number): Promise<void> {
+async function registerWith(grid: DataGridElement): Promise<void> {
   try {
     await grid.ready?.();
   } catch {
     return;
   }
   if (cancelled) return;
+  // Read props AFTER ready() resolves so any id/order change that happened
+  // while ready was pending is honored on the initial registration (the
+  // re-register watch below only fires for changes AFTER `registeredId`
+  // is set, so a race window exists without this read-after-await).
+  const id = contentId.value;
+  const order = props.order;
   const def: HeaderContentDefinition = {
     id,
     order,
@@ -96,7 +102,7 @@ function unregister(grid: DataGridElement | null, id: string | null): void {
 onMounted(() => {
   const grid = gridRef.value;
   if (!grid) return;
-  void registerWith(grid, contentId.value, props.order);
+  void registerWith(grid);
 });
 
 // Re-register if id or order changes after mount.
@@ -106,7 +112,7 @@ watch([contentId, () => props.order], async ([nextId, nextOrder], [prevId, prevO
   if (registeredId && (nextId !== prevId || nextOrder !== prevOrder)) {
     unregister(grid, registeredId);
     registeredId = null;
-    await registerWith(grid, nextId, nextOrder);
+    await registerWith(grid);
   }
 });
 

--- a/libs/grid-vue/src/lib/TbwGridShellContent.spec.ts
+++ b/libs/grid-vue/src/lib/TbwGridShellContent.spec.ts
@@ -80,9 +80,13 @@ afterEach(() => {
   document.body.innerHTML = '';
 });
 
-async function mountWith(component: ReturnType<typeof defineComponent>): Promise<Harness> {
-  const m = makeGrid();
-  const gridRef = ref<DataGridElement | null>(m.grid as DataGridElement);
+async function mountWith(
+  component: ReturnType<typeof defineComponent>,
+  opts: { grid?: MockGrid | null } = {},
+): Promise<Harness> {
+  const m = opts.grid === undefined ? makeGrid() : null;
+  const grid = opts.grid === undefined ? m!.grid : opts.grid;
+  const gridRef = ref<DataGridElement | null>((grid as DataGridElement | null) ?? null);
   const app = createApp(component);
   app.provide(GRID_ELEMENT_KEY, gridRef);
   app.mount(mountEl);
@@ -94,12 +98,12 @@ async function mountWith(component: ReturnType<typeof defineComponent>): Promise
   return {
     app,
     mountEl,
-    grid: m.grid,
-    slot: m.slot,
-    headerDefs: m.headerDefs,
-    toolbarDefs: m.toolbarDefs,
-    unregisteredHeader: m.unregisteredHeader,
-    unregisteredToolbar: m.unregisteredToolbar,
+    grid: (grid ?? makeGrid().grid) as MockGrid,
+    slot: m?.slot ?? document.createElement('div'),
+    headerDefs: m?.headerDefs ?? [],
+    toolbarDefs: m?.toolbarDefs ?? [],
+    unregisteredHeader: m?.unregisteredHeader ?? [],
+    unregisteredToolbar: m?.unregisteredToolbar ?? [],
   };
 }
 
@@ -156,6 +160,81 @@ describe('TbwGridHeaderContent', () => {
     currentApp = null;
     expect(h.unregisteredHeader).toContain('hdr-4');
   });
+
+  it('re-registers when id changes after mount', async () => {
+    const idProp = ref('hdr-id-a');
+    const h = await mountWith(
+      defineComponent({
+        setup: () => () => h2(TbwGridHeaderContent, { id: idProp.value }, () => h2('span', null, 'x')),
+      }),
+    );
+    expect(h.headerDefs.map((d) => d.id)).toEqual(['hdr-id-a']);
+    idProp.value = 'hdr-id-b';
+    await nextTick();
+    await Promise.resolve();
+    await nextTick();
+    expect(h.unregisteredHeader).toContain('hdr-id-a');
+    expect(h.headerDefs.map((d) => d.id)).toEqual(['hdr-id-a', 'hdr-id-b']);
+  });
+
+  it('re-registers when order changes after mount', async () => {
+    const orderProp = ref(1);
+    const h = await mountWith(
+      defineComponent({
+        setup: () => () =>
+          h2(TbwGridHeaderContent, { id: 'hdr-ord', order: orderProp.value }, () => h2('span', null, 'x')),
+      }),
+    );
+    orderProp.value = 9;
+    await nextTick();
+    await Promise.resolve();
+    await nextTick();
+    expect(h.unregisteredHeader).toContain('hdr-ord');
+    expect(h.headerDefs.map((d) => d.order)).toEqual([1, 9]);
+  });
+
+  it('falls back to generated id when id prop becomes undefined', async () => {
+    const idProp = ref<string | undefined>('hdr-named');
+    const h = await mountWith(
+      defineComponent({
+        setup: () => () => h2(TbwGridHeaderContent, { id: idProp.value }, () => h2('span', null, 'x')),
+      }),
+    );
+    idProp.value = undefined;
+    await nextTick();
+    await Promise.resolve();
+    await nextTick();
+    const newId = h.headerDefs[1]?.id;
+    expect(newId).toMatch(/^tbw-header-content-/);
+  });
+
+  it('skips registration when grid.ready() rejects', async () => {
+    const m = makeGrid();
+    (m.grid.ready as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('boom'));
+    const gridRef = ref<DataGridElement | null>(m.grid as DataGridElement);
+    const app = createApp(
+      defineComponent({
+        setup: () => () => h2(TbwGridHeaderContent, { id: 'hdr-rej' }, () => h2('span', null, 'x')),
+      }),
+    );
+    app.provide(GRID_ELEMENT_KEY, gridRef);
+    app.mount(mountEl);
+    currentApp = app;
+    await nextTick();
+    await Promise.resolve();
+    await nextTick();
+    expect(m.grid.registerHeaderContent).not.toHaveBeenCalled();
+  });
+
+  it('does not register when no parent grid is provided', async () => {
+    const h = await mountWith(
+      defineComponent({
+        setup: () => () => h2(TbwGridHeaderContent, { id: 'hdr-nogrid' }, () => h2('span', null, 'x')),
+      }),
+      { grid: null },
+    );
+    expect(h.headerDefs).toHaveLength(0);
+  });
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
@@ -182,6 +261,65 @@ describe('TbwGridToolbarContent', () => {
     h.app.unmount();
     currentApp = null;
     expect(h.unregisteredToolbar).toContain('tb-2');
+  });
+
+  it('re-registers when id changes after mount', async () => {
+    const idProp = ref('tb-id-a');
+    const h = await mountWith(
+      defineComponent({
+        setup: () => () => h2(TbwGridToolbarContent, { id: idProp.value }, () => h2('button', null, 'go')),
+      }),
+    );
+    idProp.value = 'tb-id-b';
+    await nextTick();
+    await Promise.resolve();
+    await nextTick();
+    expect(h.unregisteredToolbar).toContain('tb-id-a');
+    expect(h.toolbarDefs.map((d) => d.id)).toEqual(['tb-id-a', 'tb-id-b']);
+  });
+
+  it('re-registers when order changes after mount', async () => {
+    const orderProp = ref(1);
+    const h = await mountWith(
+      defineComponent({
+        setup: () => () =>
+          h2(TbwGridToolbarContent, { id: 'tb-ord', order: orderProp.value }, () => h2('button', null, 'go')),
+      }),
+    );
+    orderProp.value = 9;
+    await nextTick();
+    await Promise.resolve();
+    await nextTick();
+    expect(h.unregisteredToolbar).toContain('tb-ord');
+    expect(h.toolbarDefs.map((d) => d.order)).toEqual([1, 9]);
+  });
+
+  it('skips registration when grid.ready() rejects', async () => {
+    const m = makeGrid();
+    (m.grid.ready as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('boom'));
+    const gridRef = ref<DataGridElement | null>(m.grid as DataGridElement);
+    const app = createApp(
+      defineComponent({
+        setup: () => () => h2(TbwGridToolbarContent, { id: 'tb-rej' }, () => h2('button', null, 'go')),
+      }),
+    );
+    app.provide(GRID_ELEMENT_KEY, gridRef);
+    app.mount(mountEl);
+    currentApp = app;
+    await nextTick();
+    await Promise.resolve();
+    await nextTick();
+    expect(m.grid.registerToolbarContent).not.toHaveBeenCalled();
+  });
+
+  it('does not register when no parent grid is provided', async () => {
+    const h = await mountWith(
+      defineComponent({
+        setup: () => () => h2(TbwGridToolbarContent, { id: 'tb-nogrid' }, () => h2('button', null, 'go')),
+      }),
+      { grid: null },
+    );
+    expect(h.toolbarDefs).toHaveLength(0);
   });
 });
 

--- a/libs/grid-vue/src/lib/TbwGridShellContent.spec.ts
+++ b/libs/grid-vue/src/lib/TbwGridShellContent.spec.ts
@@ -1,0 +1,191 @@
+/**
+ * Tests for TbwGridHeaderContent and TbwGridToolbarContent SFC wrappers.
+ *
+ * @vitest-environment happy-dom
+ */
+import type { DataGridElement, HeaderContentDefinition, ToolbarContentDefinition } from '@toolbox-web/grid';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createApp, defineComponent, h, nextTick, ref, type App } from 'vue';
+import TbwGridHeaderContent from './TbwGridHeaderContent.vue';
+import TbwGridToolbarContent from './TbwGridToolbarContent.vue';
+import { GRID_ELEMENT_KEY } from './use-grid';
+
+interface MockGrid {
+  ready: () => Promise<void>;
+  registerHeaderContent: (def: HeaderContentDefinition) => void;
+  unregisterHeaderContent: (id: string) => void;
+  registerToolbarContent: (def: ToolbarContentDefinition) => void;
+  unregisterToolbarContent: (id: string) => void;
+}
+
+interface Harness {
+  app: App;
+  grid: MockGrid;
+  slot: HTMLElement;
+  mountEl: HTMLElement;
+  headerDefs: HeaderContentDefinition[];
+  toolbarDefs: ToolbarContentDefinition[];
+  unregisteredHeader: string[];
+  unregisteredToolbar: string[];
+}
+
+function makeGrid(): {
+  grid: MockGrid;
+  slot: HTMLElement;
+  headerDefs: HeaderContentDefinition[];
+  toolbarDefs: ToolbarContentDefinition[];
+  unregisteredHeader: string[];
+  unregisteredToolbar: string[];
+} {
+  const slot = document.createElement('div');
+  const headerDefs: HeaderContentDefinition[] = [];
+  const toolbarDefs: ToolbarContentDefinition[] = [];
+  const unregisteredHeader: string[] = [];
+  const unregisteredToolbar: string[] = [];
+  const grid: MockGrid = {
+    ready: vi.fn().mockResolvedValue(undefined),
+    registerHeaderContent: vi.fn((def: HeaderContentDefinition) => {
+      headerDefs.push(def);
+      def.render(slot);
+    }),
+    unregisterHeaderContent: vi.fn((id: string) => {
+      unregisteredHeader.push(id);
+    }),
+    registerToolbarContent: vi.fn((def: ToolbarContentDefinition) => {
+      toolbarDefs.push(def);
+      def.render(slot);
+    }),
+    unregisterToolbarContent: vi.fn((id: string) => {
+      unregisteredToolbar.push(id);
+    }),
+  };
+  return { grid, slot, headerDefs, toolbarDefs, unregisteredHeader, unregisteredToolbar };
+}
+
+let mountEl: HTMLElement;
+let currentApp: App | null = null;
+
+beforeEach(() => {
+  mountEl = document.createElement('div');
+  document.body.appendChild(mountEl);
+});
+
+afterEach(() => {
+  try {
+    currentApp?.unmount();
+  } catch {
+    /* ignore */
+  }
+  currentApp = null;
+  document.body.innerHTML = '';
+});
+
+async function mountWith(component: ReturnType<typeof defineComponent>): Promise<Harness> {
+  const m = makeGrid();
+  const gridRef = ref<DataGridElement | null>(m.grid as unknown as DataGridElement);
+  const app = createApp(component);
+  app.provide(GRID_ELEMENT_KEY, gridRef);
+  app.mount(mountEl);
+  currentApp = app;
+  // Allow onMounted + awaited ready to flush.
+  await nextTick();
+  await Promise.resolve();
+  await nextTick();
+  return {
+    app,
+    mountEl,
+    grid: m.grid,
+    slot: m.slot,
+    headerDefs: m.headerDefs,
+    toolbarDefs: m.toolbarDefs,
+    unregisteredHeader: m.unregisteredHeader,
+    unregisteredToolbar: m.unregisteredToolbar,
+  };
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// TbwGridHeaderContent
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('TbwGridHeaderContent', () => {
+  it('registers with the grid using provided id + order after ready resolves', async () => {
+    const h = await mountWith(
+      defineComponent({
+        setup: () => () =>
+          h2(TbwGridHeaderContent, { id: 'hdr-1', order: 5 }, () => h2('span', { 'data-testid': 'hdr' }, 'hello')),
+      }),
+    );
+    expect(h.grid.ready).toHaveBeenCalled();
+    expect(h.headerDefs).toHaveLength(1);
+    expect(h.headerDefs[0]).toMatchObject({ id: 'hdr-1', order: 5 });
+  });
+
+  it('teleports slot content into the grid-provided container', async () => {
+    const h = await mountWith(
+      defineComponent({
+        setup: () => () =>
+          h2(TbwGridHeaderContent, { id: 'hdr-2' }, () => h2('span', { 'data-testid': 'hdr' }, 'hello')),
+      }),
+    );
+    await nextTick();
+    expect(h.slot.querySelector('[data-testid="hdr"]')?.textContent).toBe('hello');
+  });
+
+  it('updates teleported content reactively without re-registering', async () => {
+    const label = ref('first');
+    const h = await mountWith(
+      defineComponent({
+        setup: () => () =>
+          h2(TbwGridHeaderContent, { id: 'hdr-3' }, () => h2('span', { 'data-testid': 'hdr' }, label.value)),
+      }),
+    );
+    await nextTick();
+    label.value = 'second';
+    await nextTick();
+    expect(h.grid.registerHeaderContent).toHaveBeenCalledTimes(1);
+    expect(h.slot.querySelector('[data-testid="hdr"]')?.textContent).toBe('second');
+  });
+
+  it('unregisters on unmount', async () => {
+    const h = await mountWith(
+      defineComponent({
+        setup: () => () => h2(TbwGridHeaderContent, { id: 'hdr-4' }, () => h2('span', null, 'x')),
+      }),
+    );
+    h.app.unmount();
+    currentApp = null;
+    expect(h.unregisteredHeader).toContain('hdr-4');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// TbwGridToolbarContent
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('TbwGridToolbarContent', () => {
+  it('registers with the grid using provided id + order', async () => {
+    const h = await mountWith(
+      defineComponent({
+        setup: () => () => h2(TbwGridToolbarContent, { id: 'tb-1', order: 3 }, () => h2('button', null, 'go')),
+      }),
+    );
+    expect(h.toolbarDefs).toHaveLength(1);
+    expect(h.toolbarDefs[0]).toMatchObject({ id: 'tb-1', order: 3 });
+  });
+
+  it('unregisters on unmount', async () => {
+    const h = await mountWith(
+      defineComponent({
+        setup: () => () => h2(TbwGridToolbarContent, { id: 'tb-2' }, () => h2('button', null, 'go')),
+      }),
+    );
+    h.app.unmount();
+    currentApp = null;
+    expect(h.unregisteredToolbar).toContain('tb-2');
+  });
+});
+
+// `h` from vue collides with our harness object — alias.
+function h2(...args: Parameters<typeof h>): ReturnType<typeof h> {
+  return h(...args);
+}

--- a/libs/grid-vue/src/lib/TbwGridShellContent.spec.ts
+++ b/libs/grid-vue/src/lib/TbwGridShellContent.spec.ts
@@ -10,7 +10,7 @@ import TbwGridHeaderContent from './TbwGridHeaderContent.vue';
 import TbwGridToolbarContent from './TbwGridToolbarContent.vue';
 import { GRID_ELEMENT_KEY } from './use-grid';
 
-interface MockGrid {
+interface MockGrid extends Partial<DataGridElement> {
   ready: () => Promise<void>;
   registerHeaderContent: (def: HeaderContentDefinition) => void;
   unregisterHeaderContent: (id: string) => void;
@@ -82,7 +82,7 @@ afterEach(() => {
 
 async function mountWith(component: ReturnType<typeof defineComponent>): Promise<Harness> {
   const m = makeGrid();
-  const gridRef = ref<DataGridElement | null>(m.grid as unknown as DataGridElement);
+  const gridRef = ref<DataGridElement | null>(m.grid as DataGridElement);
   const app = createApp(component);
   app.provide(GRID_ELEMENT_KEY, gridRef);
   app.mount(mountEl);

--- a/libs/grid-vue/src/lib/TbwGridToolbarContent.vue
+++ b/libs/grid-vue/src/lib/TbwGridToolbarContent.vue
@@ -1,0 +1,124 @@
+<script setup lang="ts">
+/**
+ * Declarative wrapper around the grid's imperative
+ * `registerToolbarContent` API. Mounts its default slot into the slot the
+ * grid provides for toolbar content via Vue's built-in `<Teleport>`, so
+ * provide/inject, Pinia, Vue Router, and all other context flow through.
+ * Must be a descendant of `<TbwGrid>`.
+ *
+ * Prefer this over `<tbw-grid-tool-buttons>` (light DOM) when you need
+ * reactive props or callbacks bound to Vue component state. Use the
+ * light-DOM form for static markup that should be moved verbatim into the
+ * toolbar.
+ *
+ * @example
+ * ```vue
+ * <TbwGrid :rows="rows" :gridConfig="config">
+ *   <TbwGridToolbarContent id="calendar-nav" :order="0">
+ *     <ToolbarNav @prev="prev" @today="today" @next="next" />
+ *   </TbwGridToolbarContent>
+ * </TbwGrid>
+ * ```
+ *
+ * @since 1.9.0
+ */
+import type { DataGridElement, ToolbarContentDefinition } from '@toolbox-web/grid';
+import { inject, onBeforeUnmount, onMounted, ref, useId, watch } from 'vue';
+import { GRID_ELEMENT_KEY } from './use-grid';
+
+/**
+ * Props for `TbwGridToolbarContent`.
+ */
+const props = withDefaults(
+  defineProps<{
+    /**
+     * Unique identifier for this toolbar content entry.
+     * Defaults to a stable Vue-generated id.
+     */
+    id?: string;
+    /**
+     * Render order priority. Lower values appear first.
+     * @default 100
+     */
+    order?: number;
+  }>(),
+  { order: 100 },
+);
+
+defineSlots<{
+  /** Default slot — content rendered into the grid shell toolbar. */
+  default?: () => unknown;
+}>();
+
+const fallbackId = useId();
+const contentId = ref<string>(props.id ?? `tbw-toolbar-content-${fallbackId}`);
+watch(
+  () => props.id,
+  (next) => {
+    contentId.value = next ?? `tbw-toolbar-content-${fallbackId}`;
+  },
+);
+
+const gridRef = inject(GRID_ELEMENT_KEY, ref<DataGridElement | null>(null));
+
+const container = ref<HTMLElement | null>(null);
+
+let registeredId: string | null = null;
+let cancelled = false;
+
+async function registerWith(grid: DataGridElement, id: string, order: number): Promise<void> {
+  try {
+    await grid.ready?.();
+  } catch {
+    return;
+  }
+  if (cancelled) return;
+  const def: ToolbarContentDefinition = {
+    id,
+    order,
+    render: (el) => {
+      container.value = el;
+      // No-op cleanup — see comment in TbwGridHeaderContent.vue. Teardown
+      // happens on wrapper unmount via `unregisterToolbarContent`.
+      return () => {
+        /* intentionally empty */
+      };
+    },
+  };
+  grid.registerToolbarContent?.(def);
+  registeredId = id;
+}
+
+function unregister(grid: DataGridElement | null, id: string | null): void {
+  if (!grid || !id) return;
+  grid.unregisterToolbarContent?.(id);
+}
+
+onMounted(() => {
+  const grid = gridRef.value;
+  if (!grid) return;
+  void registerWith(grid, contentId.value, props.order);
+});
+
+watch([contentId, () => props.order], async ([nextId, nextOrder], [, prevOrder]) => {
+  const grid = gridRef.value;
+  if (!grid) return;
+  if (registeredId && (registeredId !== nextId || nextOrder !== prevOrder)) {
+    unregister(grid, registeredId);
+    registeredId = null;
+    await registerWith(grid, nextId, nextOrder);
+  }
+});
+
+onBeforeUnmount(() => {
+  cancelled = true;
+  unregister(gridRef.value, registeredId);
+  registeredId = null;
+});
+</script>
+
+<template>
+  <Teleport v-if="container" :to="container">
+    <slot />
+  </Teleport>
+</template>

--- a/libs/grid-vue/src/lib/TbwGridToolbarContent.vue
+++ b/libs/grid-vue/src/lib/TbwGridToolbarContent.vue
@@ -66,13 +66,16 @@ const container = ref<HTMLElement | null>(null);
 let registeredId: string | null = null;
 let cancelled = false;
 
-async function registerWith(grid: DataGridElement, id: string, order: number): Promise<void> {
+async function registerWith(grid: DataGridElement): Promise<void> {
   try {
     await grid.ready?.();
   } catch {
     return;
   }
   if (cancelled) return;
+  // Read props after ready() resolves — see TbwGridHeaderContent.vue.
+  const id = contentId.value;
+  const order = props.order;
   const def: ToolbarContentDefinition = {
     id,
     order,
@@ -97,16 +100,16 @@ function unregister(grid: DataGridElement | null, id: string | null): void {
 onMounted(() => {
   const grid = gridRef.value;
   if (!grid) return;
-  void registerWith(grid, contentId.value, props.order);
+  void registerWith(grid);
 });
 
-watch([contentId, () => props.order], async ([nextId, nextOrder], [, prevOrder]) => {
+watch([contentId, () => props.order], async ([nextId, nextOrder], [prevId, prevOrder]) => {
   const grid = gridRef.value;
   if (!grid) return;
-  if (registeredId && (registeredId !== nextId || nextOrder !== prevOrder)) {
+  if (registeredId && (nextId !== prevId || nextOrder !== prevOrder)) {
     unregister(grid, registeredId);
     registeredId = null;
-    await registerWith(grid, nextId, nextOrder);
+    await registerWith(grid);
   }
 });
 


### PR DESCRIPTION
- Add GridHeaderContent/GridToolbarContent (React, Angular) and TbwGridHeaderContent/TbwGridToolbarContent (Vue) declarative wrappers around registerHeaderContent/registerToolbarContent.
- Render-callback cleanup is a no-op; teardown only on framework unmount (grid reuses sticky containers across shell refreshes).
- Vue uses built-in <Teleport>; Angular directive uses host.closest('tbw-grid') + afterNextRender + DestroyRef; React splits register/portal-update effects.
- Migrate calendar demos (react, vue, angular) to the new wrappers.
- Specs: 8 React + 6 Vue + 6 Angular smoke tests.
- Docs: getting-started.mdx + README updates for each adapter; knowledge/adapters.md shell-content-wrappers section.

closes #352