### PR TITLE
ci(e2e): use system Chrome on CI to avoid playwright install hang

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,7 +256,12 @@ jobs:
   e2e:
     needs: [setup]
     if: needs.setup.outputs.should_validate == 'true'
-    runs-on: ubuntu-latest
+    # Pinned (not `ubuntu-latest`) because this job relies on the
+    # preinstalled Google Chrome shipped with the 24.04 runner image
+    # (see `channel: 'chrome'` in the Playwright configs). Letting
+    # `latest` float to a future image would silently change the
+    # browser available to e2e.
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     env:
       # Disable Nx interactive prompts for CI
@@ -291,14 +296,36 @@ jobs:
       - name: Build libraries
         run: bun run build
 
-      - name: Install Playwright browsers
-        # `bunx playwright install` has been observed to hang silently
-        # after the Chrome download finishes — the unzip-to-cache phase
-        # produces no output and can stall the runner indefinitely
-        # (confirmed: 18 min of silence between the 100 % download line
-        # and the job timeout, with no further log output). Cap this
-        # step so the next such hang fails fast instead of consuming
-        # the full 20-min e2e job budget.
+      - name: Verify system Chrome
+        # We run e2e against the system Google Chrome preinstalled on
+        # the ubuntu-24.04 runner image (Playwright configs use
+        # `channel: 'chrome'` on CI). This avoids the
+        # `bunx playwright install` hang where the unzip-to-cache phase
+        # stalls after the Chrome download finishes (18 min of silence
+        # observed → 20-min job timeout). The cache + install steps
+        # below are kept as best-effort warm-up for the bundled
+        # Chromium cache; if they hang or fail, e2e still runs via the
+        # system Chrome channel.
+        run: google-chrome --version
+
+      - name: Cache Playwright browsers
+        # Cheap insurance: if the bundled Chromium install step below
+        # ever succeeds, this cache lets subsequent runs skip the
+        # hang-prone extract phase. Keyed on bun.lock so the cache
+        # invalidates when @playwright/test bumps.
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
+      - name: Install Playwright browsers (best-effort)
+        # Opportunistic warm-up of ~/.cache/ms-playwright. The primary
+        # e2e browser is system Chrome via `channel: 'chrome'`, so a
+        # hang or failure here does not block the job — `continue-on-error`
+        # plus the 5-min timeout ensure we fail fast and proceed.
+        continue-on-error: true
         timeout-minutes: 5
         run: bunx playwright install --with-deps chromium
 

--- a/apps/docs-e2e/playwright.config.ts
+++ b/apps/docs-e2e/playwright.config.ts
@@ -35,7 +35,13 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      // On CI, use the system Google Chrome preinstalled on the
+      // ubuntu-24.04 runner image (see ci.yml `e2e` job). Avoids the
+      // `bunx playwright install` unzip-to-cache hang.
+      use: {
+        ...devices['Desktop Chrome'],
+        ...(process.env.CI ? { channel: 'chrome' as const } : {}),
+      },
     },
   ],
 

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -63,7 +63,14 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      // On CI, use the system Google Chrome preinstalled on the
+      // ubuntu-24.04 runner image. This avoids the
+      // `bunx playwright install` unzip-to-cache hang. Locally we
+      // keep Playwright's bundled Chromium for reproducibility.
+      use: {
+        ...devices['Desktop Chrome'],
+        ...(process.env.CI ? { channel: 'chrome' as const } : {}),
+      },
     },
     // Can add Firefox and WebKit for broader testing
     // {


### PR DESCRIPTION
Pin the e2e job to ubuntu-24.04 and run tests against the Google Chrome preinstalled on the runner image (Playwright `channel: 'chrome'` on CI), instead of Playwright's bundled Chromium. This removes the hang surface entirely: the failing path was `bunx playwright install`'s unzip-to-cache phase after the Chrome archive download (18 min of silence → 20-min job timeout).

Defense in depth:
- Pin `runs-on: ubuntu-24.04` so Chrome availability does not silently shift when the `ubuntu-latest` mapping rolls.
- Add a `~/.cache/ms-playwright` cache keyed on `bun.lock` — cheap insurance if we ever revert to bundled Chromium.
- Keep `playwright install` as a best-effort warm-up step (`continue-on-error: true` + 5-min timeout). On success it populates the cache; on hang/failure it no longer blocks the job because tests use system Chrome.

Local dev is unchanged: `process.env.CI` is the only gate on the channel override, so developers continue to run against Playwright's pinned Chromium for reproducibility.