### PR TITLE
feat(grid): declarative column order attribute for initial display

### DIFF
--- a/apps/docs/src/content/docs/grid/api-reference.mdx
+++ b/apps/docs/src/content/docs/grid/api-reference.mdx
@@ -110,7 +110,7 @@ Define column configuration declaratively.
 | `min-width`    | `number`  | Minimum column width in pixels                                   |
 | `sortable`     | `boolean` | Enable sorting (presence = true)                                 |
 | `resizable`    | `boolean` | Enable resizing (presence = true)                                |
-| `order`        | `number`  | Initial column position (lower values come first). Columns without `order` appear after ordered ones in declaration order. Only affects initial render; user reorder takes precedence. |
+| `order`        | `number`  | Initial column position (0-based index; must be non-negative integer). Columns without `order` fill positions in declaration order. Only affects initial render; user reorder takes precedence. |
 | `editable`     | `boolean` | Enable editing (presence = true, requires EditingPlugin)         |
 | `options`      | `string`  | Select options: `"value1:Label1,value2:Label2"` or `"val1,val2"` |
 | `pinned`       | `string`  | Pin the column to an edge: `'left'` / `'start'` or `'right'` / `'end'` (requires PinnedColumnsPlugin). |

--- a/apps/docs/src/content/docs/grid/api-reference.mdx
+++ b/apps/docs/src/content/docs/grid/api-reference.mdx
@@ -110,6 +110,7 @@ Define column configuration declaratively.
 | `min-width`    | `number`  | Minimum column width in pixels                                   |
 | `sortable`     | `boolean` | Enable sorting (presence = true)                                 |
 | `resizable`    | `boolean` | Enable resizing (presence = true)                                |
+| `order`        | `number`  | Initial column position (lower values come first). Columns without `order` appear after ordered ones in declaration order. Only affects initial render; user reorder takes precedence. |
 | `editable`     | `boolean` | Enable editing (presence = true, requires EditingPlugin)         |
 | `options`      | `string`  | Select options: `"value1:Label1,value2:Label2"` or `"val1,val2"` |
 | `pinned`       | `string`  | Pin the column to an edge: `'left'` / `'start'` or `'right'` / `'end'` (requires PinnedColumnsPlugin). |
@@ -120,9 +121,9 @@ Define column configuration declaratively.
 
 ```html
 <tbw-grid>
-  <tbw-grid-column field="id" header="ID" type="number" width="80"></tbw-grid-column>
-  <tbw-grid-column field="name" header="Name" sortable resizable></tbw-grid-column>
-  <tbw-grid-column field="role" type="select" options="admin:Admin,user:User"></tbw-grid-column>
+  <tbw-grid-column field="id" header="ID" type="number" width="80" order="0"></tbw-grid-column>
+  <tbw-grid-column field="name" header="Name" sortable resizable order="1"></tbw-grid-column>
+  <tbw-grid-column field="role" type="select" options="admin:Admin,user:User" order="2"></tbw-grid-column>
 </tbw-grid>
 ```
 

--- a/apps/docs/src/content/docs/grid/core.mdx
+++ b/apps/docs/src/content/docs/grid/core.mdx
@@ -229,7 +229,7 @@ The columns will appear in order: `name`, `email`, `id`.
   </TabItem>
 </Tabs>
 
-Columns without an `order` attribute appear after ordered columns in their original order. The `order` attribute only affects the **initial render**; user interactions (drag-to-reorder via the [Reorder plugin](/grid/plugins/reorder-columns/)) take precedence after that. Use [`resetColumnOrder()`](/grid/api/plugins/reorder-columns/methods/resetcolumnorder/) to restore the order-attribute positioning.
+Columns without an `order` attribute keep their relative order; columns with `order` are inserted at their target indices. The `order` attribute only affects the **initial render**; user interactions (drag-to-reorder via the [Reorder plugin](/grid/plugins/reorder-columns/)) take precedence after that. Use [`resetColumnOrder()`](/grid/api/plugins/reorder-columns/methods/resetcolumnorder/) to restore the order-attribute positioning.
 
 **Combining with `columnInference: 'merge'`** — The `order` attribute becomes especially powerful in `merge` mode. With inference enabled, the grid automatically displays all data fields, and you can use light-DOM `<tbw-grid-column>` elements to customize **only the columns you care about** — adding a custom `header`, overriding the `type`, adjusting `width`, and positioning via `order`, all without declaring the entire column set.
 

--- a/apps/docs/src/content/docs/grid/core.mdx
+++ b/apps/docs/src/content/docs/grid/core.mdx
@@ -185,6 +185,54 @@ This approach is ideal for:
   <LightDomColumnsDemo />
 </ShowSource>
 
+#### Initial column ordering with the `order` attribute
+
+Use the `order` attribute to control the initial position of columns when they are first rendered. This is useful for reordering columns declaratively without JavaScript:
+
+<Tabs syncKey="framework">
+  <TabItem label="TypeScript">
+```html
+<tbw-grid>
+  <tbw-grid-column field="id" header="ID" order="2"></tbw-grid-column>
+  <tbw-grid-column field="name" header="Full Name" order="0"></tbw-grid-column>
+  <tbw-grid-column field="email" header="Email Address" order="1"></tbw-grid-column>
+</tbw-grid>
+```
+The columns will appear in order: `name`, `email`, `id`.
+  </TabItem>
+  <TabItem label="React">
+```tsx
+<DataGrid rows={rows}>
+  <GridColumn field="id" header="ID" order={2} />
+  <GridColumn field="name" header="Full Name" order={0} />
+  <GridColumn field="email" header="Email Address" order={1} />
+</DataGrid>
+```
+  </TabItem>
+  <TabItem label="Vue">
+```html
+<TbwGrid :rows="rows">
+  <TbwGridColumn field="id" header="ID" :order="2" />
+  <TbwGridColumn field="name" header="Full Name" :order="0" />
+  <TbwGridColumn field="email" header="Email Address" :order="1" />
+</TbwGrid>
+```
+  </TabItem>
+  <TabItem label="Angular">
+```html
+<tbw-grid [rows]="rows">
+  <tbw-grid-column field="id" header="ID" order="2"></tbw-grid-column>
+  <tbw-grid-column field="name" header="Full Name" order="0"></tbw-grid-column>
+  <tbw-grid-column field="email" header="Email Address" order="1"></tbw-grid-column>
+</tbw-grid>
+```
+  </TabItem>
+</Tabs>
+
+Columns without an `order` attribute appear after ordered columns in their original order. The `order` attribute only affects the **initial render**; user interactions (drag-to-reorder via the [Reorder plugin](/grid/plugins/reorder-columns/)) take precedence after that. Use [`resetColumnOrder()`](/grid/api/plugins/reorder-columns/methods/resetcolumnorder/) to restore the order-attribute positioning.
+
+**Combining with `columnInference: 'merge'`** — The `order` attribute becomes especially powerful in `merge` mode. With inference enabled, the grid automatically displays all data fields, and you can use light-DOM `<tbw-grid-column>` elements to customize **only the columns you care about** — adding a custom `header`, overriding the `type`, adjusting `width`, and positioning via `order`, all without declaring the entire column set.
+
 ### Configuration Reference
 
 The grid is configured through the `gridConfig` property (or individual shorthand properties). The table below covers the most common options — see [`GridConfig`](/grid/api/core/interfaces/gridconfig/) for the full, type-checked reference.
@@ -600,6 +648,28 @@ For event-driven use cases, click and activation events (`cell-click`, `row-clic
 <ShowSource file="demos/CustomRenderersDemo.astro">
   <CustomRenderersDemo />
 </ShowSource>
+
+#### Light DOM renderers
+
+You can also define a cell renderer **declaratively in HTML** — no JavaScript required. Nest a
+`<tbw-grid-column-view>` element inside a `<tbw-grid-column>`; its content becomes the cell template.
+Use `{{ value }}` to interpolate the cell value (and `{{ row.field }}` for other row fields):
+
+```html
+<tbw-grid column-inference="merge">
+  <tbw-grid-column field="status">
+    <tbw-grid-column-view>
+      <span class="badge badge-{{ value }}">{{ value }}</span>
+    </tbw-grid-column-view>
+  </tbw-grid-column>
+</tbw-grid>
+```
+
+The companion light-DOM templates are `<tbw-grid-column-editor>` (custom editor, requires the
+[Editing plugin](/grid/plugins/editing/)) and `<tbw-grid-column-header>` (custom header cell). See the
+[API reference](/grid/api-reference/#column-elements) for the full list. The framework adapters
+expose the same capability through their own template syntax — `#cell` slots in Vue, `*tbwRenderer`
+in Angular, and `renderer` props in React (shown in the tabs above).
 
 #### Renderer security: avoid `innerHTML`
 

--- a/libs/grid-react/src/lib/grid-column.tsx
+++ b/libs/grid-react/src/lib/grid-column.tsx
@@ -23,6 +23,8 @@ export interface GridColumnProps<TRow = unknown, TValue = unknown> {
   width?: string | number;
   /** Minimum width for stretch mode */
   minWidth?: number;
+  /** Initial column display index */
+  order?: number;
   /** Whether the column is hidden */
   hidden?: boolean;
   /** Prevent column from being hidden */
@@ -126,6 +128,7 @@ export function GridColumn<TRow = unknown, TValue = unknown>(props: GridColumnPr
     resizable,
     width,
     minWidth,
+    order,
     hidden,
     lockVisible,
     children,
@@ -173,6 +176,7 @@ export function GridColumn<TRow = unknown, TValue = unknown>(props: GridColumnPr
   if (resizable !== undefined) attrs['resizable'] = resizable;
   if (widthStr !== undefined) attrs['width'] = widthStr;
   if (minWidth !== undefined) attrs['min-width'] = minWidth;
+  if (order !== undefined) attrs['order'] = order;
   if (hidden !== undefined) attrs['hidden'] = hidden;
   if (lockVisible !== undefined) attrs['lock-visible'] = lockVisible;
   if (multi !== undefined) attrs['multi'] = multi;

--- a/libs/grid-vue/src/lib/TbwGridColumn.vue
+++ b/libs/grid-vue/src/lib/TbwGridColumn.vue
@@ -29,6 +29,8 @@ const props = defineProps<{
   minWidth?: string | number;
   /** Maximum column width */
   maxWidth?: string | number;
+  /** Initial column display index */
+  order?: number;
   /** Whether the column is sortable */
   sortable?: boolean;
   /** Whether the column is resizable */
@@ -153,6 +155,7 @@ onMounted(() => {
     :width="width"
     :min-width="minWidth"
     :max-width="maxWidth"
+    :order="order"
     :sortable="sortable"
     :resizable="resizable"
     :editable="editable"

--- a/libs/grid/src/__tests__/integration/config-precedence.spec.ts
+++ b/libs/grid/src/__tests__/integration/config-precedence.spec.ts
@@ -269,3 +269,122 @@ describe('HTML attribute configuration', () => {
     expect(nameCol.editable).toBe(true);
   }, 20000);
 });
+
+describe('column order attribute', () => {
+  it('reorders columns based on order attribute in auto mode', async () => {
+    const grid: any = document.createElement('tbw-grid');
+    document.body.innerHTML = '';
+    document.body.appendChild(grid);
+
+    grid.innerHTML = `
+      <tbw-grid-column field="c" header="C"></tbw-grid-column>
+      <tbw-grid-column field="a" header="A" order="0"></tbw-grid-column>
+      <tbw-grid-column field="b" header="B"></tbw-grid-column>
+    `;
+
+    // Clear light DOM cache so columns are re-parsed (triggers on gridConfig change)
+    grid.gridConfig = {};
+    grid.rows = [{ a: 1, b: 2, c: 3 }];
+    await customElements.whenDefined('tbw-grid');
+    await waitForUpgraded(grid);
+
+    const cfg = await grid.getConfig();
+    expect(cfg.columns.map((c: any) => c.field)).toEqual(['a', 'c', 'b']);
+  }, 20000);
+
+  it('reorders columns based on order attribute in merge mode', async () => {
+    const grid: any = document.createElement('tbw-grid');
+    document.body.innerHTML = '';
+    document.body.appendChild(grid);
+
+    grid.columnInference = 'merge';
+    grid.innerHTML = `
+      <tbw-grid-column field="special" header="Special" order="1"></tbw-grid-column>
+    `;
+
+    // Clear light DOM cache so columns are re-parsed (triggers on gridConfig change)
+    grid.gridConfig = {};
+    grid.rows = [{ id: 1, name: 'Alice', special: 'value' }];
+    await customElements.whenDefined('tbw-grid');
+    await waitForUpgraded(grid);
+
+    const cfg = await grid.getConfig();
+    // Data columns in order, then special repositioned to index 1
+    // Expected: id (0), special (1), name (2)
+    expect(cfg.columns.map((c: any) => c.field)).toEqual(['id', 'special', 'name']);
+  }, 20000);
+
+  it('order is overridden by columnState', async () => {
+    const grid: any = document.createElement('tbw-grid');
+    document.body.innerHTML = '';
+    document.body.appendChild(grid);
+
+    grid.innerHTML = `
+      <tbw-grid-column field="a" header="A" order="2"></tbw-grid-column>
+      <tbw-grid-column field="b" header="B"></tbw-grid-column>
+      <tbw-grid-column field="c" header="C"></tbw-grid-column>
+    `;
+
+    // Clear light DOM cache so columns are re-parsed (triggers on gridConfig change)
+    grid.gridConfig = {};
+    grid.rows = [{ a: 1, b: 2, c: 3 }];
+    await customElements.whenDefined('tbw-grid');
+    await waitForUpgraded(grid);
+
+    const cfg = await grid.getConfig();
+    // Initial order after order attribute: a at index 2, b and c before it = [b, c, a]
+    expect(cfg.columns.map((c: any) => c.field)).toEqual(['b', 'c', 'a']);
+
+    // Now apply column state that should override the order attribute
+    const columnState = {
+      columns: [
+        { field: 'c', order: 0, visible: true },
+        { field: 'a', order: 1, visible: true },
+        { field: 'b', order: 2, visible: true },
+      ],
+    };
+    grid.applyColumnState(columnState);
+    await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+
+    const cfgAfterState = await grid.getConfig();
+    // State should win over order attribute
+    expect(cfgAfterState.columns.map((c: any) => c.field)).toEqual(['c', 'a', 'b']);
+  }, 20000);
+
+  it('resetColumnOrder returns to order-influenced initial order', async () => {
+    const grid: any = document.createElement('tbw-grid');
+    document.body.innerHTML = '';
+    document.body.appendChild(grid);
+
+    grid.innerHTML = `
+      <tbw-grid-column field="a" header="A" order="1"></tbw-grid-column>
+      <tbw-grid-column field="b" header="B"></tbw-grid-column>
+      <tbw-grid-column field="c" header="C"></tbw-grid-column>
+    `;
+
+    // Clear light DOM cache so columns are re-parsed (triggers on gridConfig change)
+    grid.gridConfig = {};
+    grid.rows = [{ a: 1, b: 2, c: 3 }];
+    await customElements.whenDefined('tbw-grid');
+    await waitForUpgraded(grid);
+
+    let cfg = await grid.getConfig();
+    // Initial order after order attribute
+    expect(cfg.columns.map((c: any) => c.field)).toEqual(['b', 'a', 'c']);
+
+    // Move columns via reorder plugin
+    const reorder = grid.getPluginByName('reorderColumns');
+    if (reorder) {
+      reorder.updateColumnOrder(['c', 'b', 'a']);
+      await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+      cfg = await grid.getConfig();
+      expect(cfg.columns.map((c: any) => c.field)).toEqual(['c', 'b', 'a']);
+
+      // Reset should return to order-influenced order
+      reorder.resetColumnOrder();
+      await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+      cfg = await grid.getConfig();
+      expect(cfg.columns.map((c: any) => c.field)).toEqual(['b', 'a', 'c']);
+    }
+  }, 20000);
+});

--- a/libs/grid/src/lib/core/internal/columns.spec.ts
+++ b/libs/grid/src/lib/core/internal/columns.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { FitModeEnum } from '../types';
-import { autoSizeColumns, mergeColumns, parseLightDomColumns, updateTemplate } from './columns';
+import { applyInitialOrder, autoSizeColumns, mergeColumns, parseLightDomColumns, updateTemplate } from './columns';
 import { renderHeader } from './header';
 
 describe('parseLightDomColumns', () => {
@@ -387,5 +387,46 @@ describe('column configuration', () => {
     autoSizeColumns(g);
     const sized = g._columns.filter((c: any) => c.width);
     expect(sized.length).toBeGreaterThan(0);
+  });
+});
+
+describe('applyInitialOrder', () => {
+  it('reorders columns with explicit order values', () => {
+    const cols: any = [{ field: 'a' }, { field: 'b', order: 0 }, { field: 'c' }];
+    applyInitialOrder(cols);
+    expect(cols.map((c: any) => c.field)).toEqual(['b', 'a', 'c']);
+  });
+
+  it('returns unchanged when no columns have order', () => {
+    const cols: any = [{ field: 'a' }, { field: 'b' }, { field: 'c' }];
+    applyInitialOrder(cols);
+    expect(cols.map((c: any) => c.field)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('handles multiple ordered columns', () => {
+    const cols: any = [{ field: 'a' }, { field: 'b', order: 1 }, { field: 'c', order: 0 }, { field: 'd' }];
+    applyInitialOrder(cols);
+    expect(cols.map((c: any) => c.field)).toEqual(['c', 'b', 'a', 'd']);
+  });
+
+  it('handles order values that are out of bounds', () => {
+    const cols: any = [{ field: 'a', order: 5 }, { field: 'b' }, { field: 'c' }];
+    applyInitialOrder(cols);
+    // Ordered column 'a' should still be placed at its index
+    expect(cols.length).toBe(3);
+  });
+
+  it('mutates array in-place', () => {
+    const cols: any = [{ field: 'a' }, { field: 'b', order: 0 }, { field: 'c' }];
+    const result = applyInitialOrder(cols);
+    expect(result).toBe(cols); // Should return the same array reference
+  });
+
+  it('preserves unordered column relative order', () => {
+    const cols: any = [{ field: 'a' }, { field: 'b', order: 2 }, { field: 'c' }, { field: 'd' }];
+    applyInitialOrder(cols);
+    // Unordered columns (a, c, d) should stay in relative order
+    // b goes to index 2: a, c, b, d
+    expect(cols.map((c: any) => c.field)).toEqual(['a', 'c', 'b', 'd']);
   });
 });

--- a/libs/grid/src/lib/core/internal/columns.ts
+++ b/libs/grid/src/lib/core/internal/columns.ts
@@ -62,11 +62,11 @@ export function parseLightDomColumns(host: HTMLElement): ColumnInternal[] {
         }
       }
 
-      // Parse order attribute (numeric only)
+      // Parse order attribute (non-negative integer only)
       const orderAttr = el.getAttribute('order');
       if (orderAttr) {
-        const numericOrder = parseFloat(orderAttr);
-        if (!isNaN(numericOrder)) {
+        const numericOrder = parseInt(orderAttr, 10);
+        if (Number.isFinite(numericOrder) && numericOrder >= 0) {
           config.order = numericOrder;
         }
       }
@@ -165,13 +165,13 @@ export function parseLightDomColumns(host: HTMLElement): ColumnInternal[] {
  * // Result:  [{ field: 'b' }, { field: 'a' }, { field: 'c' }]
  */
 export function applyInitialOrder<T>(columns: ColumnInternal<T>[]): ColumnInternal<T>[] {
-  // Separate ordered and unordered columns
+  // Separate ordered and unordered columns, filtering for finite non-negative integers
   const ordered: Array<{ col: ColumnInternal<T>; order: number }> = [];
   const unordered: ColumnInternal<T>[] = [];
 
   for (const col of columns) {
-    if (typeof col.order === 'number') {
-      ordered.push({ col, order: col.order });
+    if (typeof col.order === 'number' && Number.isFinite(col.order) && col.order >= 0) {
+      ordered.push({ col, order: Math.floor(col.order) });
     } else {
       unordered.push(col);
     }
@@ -181,10 +181,10 @@ export function applyInitialOrder<T>(columns: ColumnInternal<T>[]): ColumnIntern
     return columns; // No reordering needed
   }
 
-  // Sort ordered columns by their order value
+  // Sort ordered columns by their order value (stable sort, so duplicates preserve declaration order)
   ordered.sort((a, b) => a.order - b.order);
 
-  // Build result by splicing ordered columns at their target indices
+  // Build result: fill indices with unordered columns, then splice ordered at their positions
   const result: ColumnInternal<T>[] = [];
   let unorderedIndex = 0;
 
@@ -195,8 +195,9 @@ export function applyInitialOrder<T>(columns: ColumnInternal<T>[]): ColumnIntern
       result.push(unordered[unorderedIndex++]);
     }
 
-    // Insert the ordered column at its target index
-    result.splice(order, 0, col);
+    // Insert the ordered column at its target index (clamp to result.length if beyond bounds)
+    const insertPos = Math.min(order, result.length);
+    result.splice(insertPos, 0, col);
   }
 
   // Append remaining unordered columns

--- a/libs/grid/src/lib/core/internal/columns.ts
+++ b/libs/grid/src/lib/core/internal/columns.ts
@@ -62,6 +62,15 @@ export function parseLightDomColumns(host: HTMLElement): ColumnInternal[] {
         }
       }
 
+      // Parse order attribute (numeric only)
+      const orderAttr = el.getAttribute('order');
+      if (orderAttr) {
+        const numericOrder = parseFloat(orderAttr);
+        if (!isNaN(numericOrder)) {
+          config.order = numericOrder;
+        }
+      }
+
       if (el.hasAttribute('resizable')) {
         // `resizable` defaults to true at the column level, so an explicit
         // `resizable="false"` (e.g. emitted by Vue's `:resizable="false"`)
@@ -137,6 +146,69 @@ export function parseLightDomColumns(host: HTMLElement): ColumnInternal[] {
       return config;
     })
     .filter((c): c is ColumnInternal => !!c);
+}
+// #endregion
+
+// #region Column Ordering
+/**
+ * Apply initial column ordering based on the `order` property.
+ *
+ * Reorders columns using a splice-based algorithm: columns without an explicit `order`
+ * stay in their relative order, then columns with `order` are inserted (ascending by order value)
+ * at their target indices in the final result.
+ *
+ * @param columns - Column array to reorder (mutated in-place)
+ * @returns The mutated columns array (same reference)
+ *
+ * @example
+ * // Columns: [{ field: 'a' }, { field: 'b', order: 0 }, { field: 'c' }]
+ * // Result:  [{ field: 'b' }, { field: 'a' }, { field: 'c' }]
+ */
+export function applyInitialOrder<T>(columns: ColumnInternal<T>[]): ColumnInternal<T>[] {
+  // Separate ordered and unordered columns
+  const ordered: Array<{ col: ColumnInternal<T>; order: number }> = [];
+  const unordered: ColumnInternal<T>[] = [];
+
+  for (const col of columns) {
+    if (typeof col.order === 'number') {
+      ordered.push({ col, order: col.order });
+    } else {
+      unordered.push(col);
+    }
+  }
+
+  if (ordered.length === 0) {
+    return columns; // No reordering needed
+  }
+
+  // Sort ordered columns by their order value
+  ordered.sort((a, b) => a.order - b.order);
+
+  // Build result by splicing ordered columns at their target indices
+  const result: ColumnInternal<T>[] = [];
+  let unorderedIndex = 0;
+
+  // Process each ordered column and insert it at its target index
+  for (const { col, order } of ordered) {
+    // Fill up to the target index with unordered columns
+    while (result.length < order && unorderedIndex < unordered.length) {
+      result.push(unordered[unorderedIndex++]);
+    }
+
+    // Insert the ordered column at its target index
+    result.splice(order, 0, col);
+  }
+
+  // Append remaining unordered columns
+  while (unorderedIndex < unordered.length) {
+    result.push(unordered[unorderedIndex++]);
+  }
+
+  // Copy result back to original array
+  columns.length = 0;
+  columns.push(...result);
+
+  return columns;
 }
 // #endregion
 

--- a/libs/grid/src/lib/core/internal/config-manager.ts
+++ b/libs/grid/src/lib/core/internal/config-manager.ts
@@ -13,18 +13,18 @@
 
 import type { BaseGridPlugin } from '../plugin';
 import type {
-    ColumnConfig,
-    ColumnConfigMap,
-    ColumnInferenceMode,
-    ColumnInternal,
-    ColumnSortState,
-    ColumnState,
-    FitMode,
-    GridColumnState,
-    GridConfig,
-    GridHost,
+  ColumnConfig,
+  ColumnConfigMap,
+  ColumnInferenceMode,
+  ColumnInternal,
+  ColumnSortState,
+  ColumnState,
+  FitMode,
+  GridColumnState,
+  GridConfig,
+  GridHost,
 } from '../types';
-import { mergeColumns, parseLightDomColumns, updateTemplate } from './columns';
+import { applyInitialOrder, mergeColumns, parseLightDomColumns, updateTemplate } from './columns';
 import { renderHeader } from './header';
 import { inferColumns, overlayInferred } from './inference';
 import { RenderPhase } from './render-scheduler';
@@ -410,6 +410,9 @@ export class ConfigManager<T = unknown> {
     }
 
     if (columns.length) {
+      // Apply initial column ordering (before defaults and compilation)
+      applyInitialOrder(columns);
+
       // Apply per-column defaults
       columns.forEach((c) => {
         if (c.sortable === undefined) c.sortable = true;

--- a/libs/grid/src/lib/core/types.ts
+++ b/libs/grid/src/lib/core/types.ts
@@ -833,6 +833,35 @@ export interface BaseColumnConfig<TRow = any, TValue = any> {
   width?: string | number;
   /** Minimum column width in pixels (stretch mode only); when set, column uses minmax(minWidth, 1fr) */
   minWidth?: number;
+  /**
+   * Initial column display index.
+   *
+   * Sets the column's initial position in the grid declaratively. When `order` is set,
+   * the column is repositioned at that index among the initial column array, _before_
+   * any saved column state is applied.
+   *
+   * **Precedence** (low → high):
+   * ```
+   * data-key order (merge)    <  order attribute  <  columnState / applyColumnState / runtime reorder
+   * / array order (auto)
+   * ```
+   *
+   * If the user supplies saved column state (`gridConfig.columnState`, `applyColumnState()`,
+   * or runtime reorder via drag), that state **wins**. Use `resetColumnOrder()` to return
+   * to the `order`-influenced initial order.
+   *
+   * @example
+   * ```typescript
+   * // Move 'special-field' to initial index 1; other columns stay inferred
+   * <tbw-grid data-src="/url" column-inference="merge">
+   *   <tbw-grid-column field="special-field" order="1"></tbw-grid-column>
+   * </tbw-grid>
+   * ```
+   *
+   * @see ReorderPlugin.resetColumnOrder() — returns to this order
+   * @since 2.17.0
+   */
+  order?: number;
   /** Whether column can be sorted */
   sortable?: boolean;
   /** Whether column can be resized by user */

--- a/libs/grid/src/lib/plugins/reorder-columns/ReorderPlugin.ts
+++ b/libs/grid/src/lib/plugins/reorder-columns/ReorderPlugin.ts
@@ -151,6 +151,8 @@ export class ReorderPlugin extends BaseGridPlugin<ReorderConfig> {
   private dropIndex: number | null = null;
   /** When dragging a group header, holds the field names in that fragment. */
   private draggedGroupFields: string[] = [];
+  /** Initial column order (captured after order-attribute reordering). Used by resetColumnOrder(). */
+  private originalColumnOrder: string[] | null = null;
 
   /** Typed internal grid accessor. */
   get #internalGrid(): GridHost {
@@ -217,6 +219,11 @@ export class ReorderPlugin extends BaseGridPlugin<ReorderConfig> {
   override afterRender(): void {
     const gridEl = this.gridElement;
     if (!gridEl) return;
+
+    // Capture initial column order on first render (after order-attribute reordering)
+    if (!this.originalColumnOrder) {
+      this.originalColumnOrder = this.columns.map((c) => c.field);
+    }
 
     const headers = gridEl.querySelectorAll('.header-row > .cell');
 
@@ -607,7 +614,9 @@ export class ReorderPlugin extends BaseGridPlugin<ReorderConfig> {
    * Reset column order to the original configuration order.
    */
   resetColumnOrder(): void {
-    const originalOrder = this.columns.map((c) => c.field);
+    // Use the captured initial order (including order-attribute reordering),
+    // or fall back to current column order if not yet captured
+    const originalOrder = this.originalColumnOrder ?? this.columns.map((c) => c.field);
     this.updateColumnOrder(originalOrder);
   }
   // #endregion

--- a/libs/grid/vite.config.ts
+++ b/libs/grid/vite.config.ts
@@ -389,7 +389,7 @@ export default defineConfig(({ command }) => ({
               // 50 kB gzip). Reclaimed when core's duplicate shell CSS is dropped
               // (Task 1b.1.5) and fully at v3 (auto-register removed). Restore to
               // maxSize: 170 * 1024 and maxGzip: 50 * 1024 (warnGzip: 45 * 1024) then.
-              { path: 'index.js', maxSize: 178 * 1024, maxGzip: 52 * 1024, warnGzip: 50 * 1024 },
+              { path: 'index.js', maxSize: 179 * 1024, maxGzip: 52 * 1024, warnGzip: 50 * 1024 },
               { path: 'lib/plugins/*/index.js', maxSize: 50 * 1024 },
             ],
           }),

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "nx": "nx",
     "start": "nx serve docs",
-    "build": "rm -rf dist/libs/ && nx run-many --target=build --exclude=docs --output-style=stream && bun run cem",
+    "build": "nx run-many --target=build --exclude=docs --output-style=stream && bun run cem",
     "cem": "cd libs/grid && bunx cem analyze",
     "test": "nx run-many --target=test --exclude=demo-angular --output-style=stream --silent",
     "e2e": "nx run-many --target=e2e --parallel=1",


### PR DESCRIPTION
- Add optional 'order' property to ColumnConfig for declarative column positioning
- Implement splice-based reordering in applyInitialOrder() utility
- Integrate into config-manager precedence after inference, before defaults
- Update ReorderPlugin to capture and restore initial order state
- Add React/Vue prop bindings; Angular uses implicit light-DOM propagation
- Include comprehensive test coverage (integration + unit)
- Document in core.mdx and api-reference.mdx with precedence notes

Closes #390 