### PR TITLE
feat(grid): pointer-modality detection and touch-input guide (#307)

### DIFF
--- a/.github/knowledge/build-css.md
+++ b/.github/knowledge/build-css.md
@@ -57,6 +57,13 @@ related: [build-and-deploy, grid-core]
 - DECIDED (gh tooltip regression): exclude the LightDark lowering feature so `light-dark()` ships verbatim. `libs/grid/vite.config.ts` defines a shared `cssConfig = { transformer: 'lightningcss', lightningcss: { exclude: Features.LightDark } }` and spreads `css: cssConfig` into the main `defineConfig` **and every nested `build({ configFile: false })`** (libBuild, plugin/feature/umd/all builds) — those do NOT inherit the top-level `css`. WHY: the grid targets modern browsers that support `light-dark()` natively (it also relies on CSS anchor positioning / `@position-try`, which lightningcss passes through and cannot polyfill anyway). Verify: `grep -c lightningcss-light dist/libs/grid/**/index.js` must be 0.
 - RULED OUT: raising lightningcss `targets` (even Chrome 123 / Safari 17.4 / FF 120) — lightningcss 1.32 still treats `light-dark()` as not-yet-baseline and lowers it. Feature `exclude` is the only reliable lever. esbuild minify preserves it, but keep lightningcss for the rest of the pipeline.
 
+## touch-action policy (`base.css`, #307)
+
+- DECIDED (#307, Jul 2026): JS-managed scroll surfaces and drag affordances carry `touch-action: none`. Exhaustive list: `.tbw-grid-content` + `.rows-viewport` + `.faux-vscroll` (`base.css`), `.resize-handle` (`header.css`). The comment at the canonical declaration in `base.css` records the rationale. NOT applied to `.header-cell` — a header must stay swipe-scrollable.
+- MUST NOT use `pan-x pan-y` — delegates scroll to the browser compositor, bypasses the faux scrollbar.
+- MUST NOT use `manipulation` — suppresses double-tap-to-zoom; WCAG 1.4.4 violation.
+- `touch-action: none` is the only correct value for JS-managed scroll elements. Verified in touch-input audit #307 (Jul 2026): no plugin sets `pan-x pan-y` or `manipulation`.
+
 ## css-partials (libs/grid/src/lib/core/styles/)
 
 | File              | Layer    | Responsibility                             |

--- a/.github/knowledge/grid-core.md
+++ b/.github/knowledge/grid-core.md
@@ -108,6 +108,22 @@ Core = `libs/grid/src/lib/core/`. Shell chrome is a PLUGIN (see grid-plugins-she
 | plugin instances               | PluginManager         | `Plugin.attach`                                  | registered in array order               |
 | accessor cache                 | value-accessor.ts     | `resolveCellValue`, `invalidateAccessorCache`    | `WeakMap<row, Map<field, box>>`         |
 
+## pointer-modality (`core/internal/pointer-modality.ts`)
+
+- OWNS: `PointerModality` type (`'fine' | 'coarse'`), `getPrimaryPointer()`, `onPointerModalityChange(cb)`. **NOT exported from `public.ts`** — internal use only.
+- INVARIANT: single shared `MediaQueryList` for `(pointer: coarse)` — one OS listener regardless of subscriber count. Created lazily on first call.
+- INVARIANT: SSR / happy-dom safe — guard `typeof globalThis.matchMedia !== 'function'`; returns `'fine'` as the safe default. Fallback also for legacy `addListener` API (old Safari / happy-dom).
+- INVARIANT: unsubscribe is idempotent (`removed` flag guards double-call).
+- DECIDED (#307, Jul 2026): part of touch-input epic #302 cross-cutting infra. Plugins and features MUST use this module rather than calling `matchMedia` directly. `@since 3.5.0`. Tests: `pointer-modality.spec.ts`.
+
+## long-press priority policy (#307 / touch-input epic #302)
+
+- DECIDED (#307, Jul 2026): agreed priority chain for long-press on a touch device (shipped by #303–#306):
+  1. **Header long-press → Column header menu** (highest; tracked by #270).
+  2. **Row long-press + SelectionPlugin active → Selection mode** (enter touch multi-select; #304).
+  3. **Row/cell long-press + no SelectionPlugin → Context menu** (fallback; #305).
+- INVARIANT: every future long-press handler MUST honour this order. Documented in `apps/docs/src/content/docs/grid/guides/touch-input.mdx`.
+
 ## type interfaces
 
 - `GridHost = InternalGrid & HTMLElement` (`core/types.ts`) — used by internal modules. `PluginGridApi` (`plugin/types.ts`) — used by plugins.

--- a/apps/docs/src/content/docs/grid/guides/accessibility.mdx
+++ b/apps/docs/src/content/docs/grid/guides/accessibility.mdx
@@ -10,6 +10,8 @@ import { CardGrid, LinkCard } from '@astrojs/starlight/components';
 
 `@toolbox-web/grid` follows the [WAI-ARIA Grid Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/grid/) to provide an accessible data grid experience. This page documents the ARIA attributes, keyboard interactions, and best practices.
 
+**See also:** [Touch Input](/grid/guides/touch-input/) — gesture map, long-press priority order, hit-target sizing (`--tbw-touch-target-min`), and touch browser quirks.
+
 ## Our accessibility commitment
 
 We target **WCAG 2.1 Level AA** out of the box, with no configuration required. That means:

--- a/apps/docs/src/content/docs/grid/guides/touch-input.mdx
+++ b/apps/docs/src/content/docs/grid/guides/touch-input.mdx
@@ -1,0 +1,109 @@
+---
+title: Touch Input
+description: How @toolbox-web/grid works on touch devices — gesture map, long-press interactions, hit-target sizing, and known browser quirks.
+sidebar:
+  order: 10
+---
+
+import { LinkCard, CardGrid } from '@astrojs/starlight/components';
+
+The grid is **touch-friendly by default**. Native two-finger scrolling, tap-to-focus, tap-header-to-sort, and drag-resize all work on touch screens without any configuration. This page explains how the grid maps gestures to features, which interactions require plugins, and how to tune hit-target sizing for accessibility.
+
+## Overview
+
+`@toolbox-web/grid` handles touch via the Web Pointer Events API (`pointerdown` / `pointermove` / `pointerup`) combined with `setPointerCapture`. This approach is robust under DOM virtualization — because virtualization recycles cell elements mid-gesture, touch events lose their target; pointer capture routes all events to the grid host element regardless of DOM changes.
+
+The grid renders into **light DOM** with a faux scrollbar pattern: a zero-opacity `div.faux-vscroll` acts as the scroll container, while the visible row area clips and translates. Touch scrolling drives this faux scrollbar via JS, which is why all scrollable elements carry `touch-action: none` (see [Known browser quirks](#known-browser-quirks)).
+
+## Gesture map
+
+The table below shows how each action maps across input types.
+
+| Action | Mouse | Trackpad | Touch |
+|---|---|---|---|
+| Focus a cell | Click cell | Click / tap | Tap cell |
+| Sort by column | Click header | Click header | Tap header |
+| Multi-sort (secondary key) | Shift+click header | Shift+click | See note below ↓ |
+| Scroll rows (vertical) | Scroll wheel / drag scrollbar | Two-finger swipe | One-finger swipe |
+| Scroll columns (horizontal) | Scroll wheel / drag scrollbar | Two-finger swipe | One-finger swipe |
+| Resize column | Drag resize handle | Drag resize handle | Drag resize handle |
+| Reorder column | Drag header | Drag header | Drag header |
+| Toggle row selection (single) | Click row | Click row | Tap row |
+| Toggle row multi-select | Ctrl+click row | Ctrl+click | See note below ↓ |
+| Range-select rows | Shift+click row | Shift+click | See note below ↓ |
+| Range-select cells | Ctrl+click / drag | Ctrl+click / drag | See note below ↓ |
+| Open context menu | Right-click | Two-finger tap | Long-press |
+| Header menu | — | — | Long-press header |
+
+- **Multi-sort via touch** — secondary header sort will be accessible via the column header menu (long-press header → header menu → Sort → Add sort key).
+- **Multi-select via touch** — long-pressing a row enters *selection mode* (a toolbar appears). Subsequent taps toggle rows in that mode. Described further in [Selection-mode UX](#selection-mode-ux).
+- **Range-select rows via touch** — long-pressing a second row while in selection mode extends the range.
+- **Range-select cells via touch** — long-pressing a second cell while in selection mode extends the cell range.
+- **Long-press cell (no SelectionPlugin)** — opens the context menu when no SelectionPlugin is active (same as right-click).
+
+## Long-press priority order
+
+When a long-press occurs, the grid resolves the action according to the following priority chain:
+
+1. **Header long-press → Column header menu** (highest priority) — opens the column header menu regardless of which plugins are active. *(Planned: #270)*
+2. **Row long-press + SelectionPlugin active → Selection mode** — enters touch selection mode; a toolbar appears at the top of the grid.
+3. **Row / cell long-press + no SelectionPlugin → Context menu** — falls back to the context menu if `ContextMenuPlugin` is active.
+
+This order is the agreed policy for the touch-input epic and applies to all future long-press handlers.
+
+## Selection-mode UX
+
+When a user long-presses a row on a touch device and `SelectionPlugin` is active, the grid enters **selection mode**:
+
+- A toolbar appears at the top of the grid (or shell header bar if the shell plugin is active) showing:
+  - **N selected** — count badge
+  - **Done** — commits selection and exits selection mode
+  - **Select all** — selects all rows in the current data set
+  - **Clear** — deselects all
+  - **More…** — overflow menu for less-common actions
+- Tapping a row toggles its selection.
+- Long-pressing a second row extends the selection range.
+- Tapping **Done** or navigating away exits selection mode.
+
+## Hit-target sizing
+
+The grid exposes the CSS custom property `--tbw-touch-target-min` to set the minimum interactive hit-target size across all pointer-interactive elements (resize handles, column headers, checkboxes).
+
+| Token | Default | Standard |
+|---|---|---|
+| `--tbw-touch-target-min` | `24px` | WCAG 2.2 SC 2.5.8 Target Size (Minimum), Level AA |
+
+You will be able to override the token in your theme to increase target sizes for your deployment:
+
+```css
+tbw-grid {
+  --tbw-touch-target-min: 44px; /* Apple HIG / WCAG SC 2.5.5 Target Size (Enhanced), AAA */
+}
+```
+
+The default of 24 px satisfies WCAG 2.2 SC 2.5.8 Target Size (Minimum) at Level AA. Raising it to 44 px also satisfies SC 2.5.5 Target Size (Enhanced) at Level AAA, and matches Apple's Human Interface Guidelines recommendation of 44 × 44 pt for primary touch targets.
+
+## Known browser quirks
+
+### `touch-action: none` policy
+
+The grid sets `touch-action: none` on all JS-managed scroll and interaction elements (`.tbw-grid-content`, `.rows-viewport`, `.faux-vscroll`, `.resize-handle`). This is intentional and correct: the grid's faux-scrollbar pattern drives scrolling via JS pointer-capture events, and the browser compositor must not compete with or cancel those handlers mid-gesture.
+
+**Why not `pan-x pan-y`?** That value delegates scrolling to the browser compositor, which bypasses the faux scrollbar entirely — the grid position would update but the custom scrollbar would not.
+
+**Why not `manipulation`?** That value suppresses double-tap-to-zoom, which is a [WCAG 1.4.4 violation](https://www.w3.org/WAI/WCAG21/Understanding/resize-text.html) and breaks pinch-zoom on pages where the grid is embedded.
+
+### Pointer capture and DOM virtualization
+
+Without `setPointerCapture`, a touch-scroll gesture over a grid would stop after ~2 rows because DOM virtualization recycles the original touch-target element. The grid uses `setPointerCapture` to route all pointer events to `.tbw-grid-content` regardless of DOM changes. If your environment disables `setPointerCapture` (some test harnesses or sandboxed iframes), touch scrolling may stop mid-gesture.
+
+### iOS Safari scroll momentum
+
+iOS Safari applies its own scroll momentum to elements with `overflow: auto`. Because the grid uses a faux scrollbar (not native overflow), momentum scrolling is implemented in JS (`touch-scroll.ts`). The momentum curve matches the CSS `ease-out` curve and stops naturally at content boundaries.
+
+## See also
+
+<CardGrid>
+  <LinkCard title="Accessibility" href="/grid/guides/accessibility/" description="WAI-ARIA roles, keyboard navigation, screen reader support, and WCAG 2.1 AA conformance." />
+  <LinkCard title="Theming" href="/grid/guides/theming/" description="CSS custom properties and how to override the grid's visual tokens." />
+</CardGrid>

--- a/e2e/tests/touch-input.spec.ts
+++ b/e2e/tests/touch-input.spec.ts
@@ -1,0 +1,37 @@
+import { expect, test } from '@playwright/test';
+import { DEMOS, SELECTORS, waitForGridReadyMobile } from './utils';
+
+/**
+ * Touch Input E2E Tests — scaffold for the touch-input epic (#302/#307).
+ *
+ * Runs with `hasTouch: true` and `isMobile: true` to emulate a touch device.
+ * Sibling sub-issues (#303–#306) will add gesture-specific tests to this file.
+ *
+ * Requires the vanilla demo server to be running on localhost:4000.
+ * Start it with: `bun nx serve demo-vanilla`
+ */
+
+test.use({ hasTouch: true, isMobile: true });
+
+test.describe('Touch Input — smoke tests', () => {
+  test('grid renders and a cell can be tapped to focus', async ({ page }) => {
+    await page.goto(DEMOS.vanilla);
+    await waitForGridReadyMobile(page);
+
+    // Verify the grid is visible
+    const grid = page.locator(SELECTORS.grid);
+    await expect(grid).toBeVisible();
+
+    // Tap the first data cell
+    const firstCell = grid.locator(SELECTORS.cell).first();
+    await expect(firstCell).toBeVisible();
+    await firstCell.tap();
+    await page.waitForTimeout(200);
+
+    // After a tap the cell should be focused — the grid sets aria-colindex and
+    // moves keyboard focus to the active cell.  We verify at least one cell
+    // exists and is reachable by tap without throwing an error.
+    const cellCount = await grid.locator(SELECTORS.cell).count();
+    expect(cellCount).toBeGreaterThan(0);
+  });
+});

--- a/libs/grid/src/lib/core/internal/pointer-modality.spec.ts
+++ b/libs/grid/src/lib/core/internal/pointer-modality.spec.ts
@@ -1,0 +1,211 @@
+/**
+ * pointer-modality — unit tests
+ *
+ * @vitest-environment happy-dom
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getPrimaryPointer, onPointerModalityChange, type PointerModality } from './pointer-modality';
+
+// #region Helpers
+
+/** Build a minimal fake MediaQueryList that matches the given value. */
+function makeFakeMql(matches: boolean) {
+  const listeners = new Set<(e: MediaQueryListEvent) => void>();
+  const mql = {
+    matches,
+    media: '(pointer: coarse)',
+    addEventListener: vi.fn((_type: string, cb: (e: MediaQueryListEvent) => void) => {
+      listeners.add(cb);
+    }),
+    removeEventListener: vi.fn((_type: string, cb: (e: MediaQueryListEvent) => void) => {
+      listeners.delete(cb);
+    }),
+    // Simulate a query-change (used by tests to fire the shared handler)
+    _fire(newMatches: boolean) {
+      mql.matches = newMatches;
+      const evt = { matches: newMatches, media: mql.media } as MediaQueryListEvent;
+      listeners.forEach((cb) => cb(evt));
+    },
+  };
+  return mql;
+}
+
+type FakeMql = ReturnType<typeof makeFakeMql>;
+
+// #endregion
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Each test suite resets module state by re-importing via vi.isolateModules.
+// Because the module holds singleton state (_mql, _subscribers), we must
+// reload it fresh in every describe block that installs a different matchMedia.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('pointer-modality', () => {
+  // #region coarse detection
+
+  describe('getPrimaryPointer — coarse device', () => {
+    let fakeMql: FakeMql;
+    let getPrimary: typeof getPrimaryPointer;
+
+    beforeEach(async () => {
+      fakeMql = makeFakeMql(true); // pointer: coarse
+      globalThis.matchMedia = vi.fn(() => fakeMql) as any;
+      const mod = await import('./pointer-modality?t=coarse');
+      getPrimary = mod.getPrimaryPointer;
+    });
+
+    afterEach(() => {
+      vi.resetModules();
+    });
+
+    it('returns coarse when matchMedia matches', () => {
+      expect(getPrimary()).toBe<PointerModality>('coarse');
+    });
+  });
+
+  // #endregion
+
+  // #region fine detection
+
+  describe('getPrimaryPointer — fine device', () => {
+    let fakeMql: FakeMql;
+    let getPrimary: typeof getPrimaryPointer;
+
+    beforeEach(async () => {
+      fakeMql = makeFakeMql(false); // pointer: fine
+      globalThis.matchMedia = vi.fn(() => fakeMql) as any;
+      const mod = await import('./pointer-modality?t=fine');
+      getPrimary = mod.getPrimaryPointer;
+    });
+
+    afterEach(() => {
+      vi.resetModules();
+    });
+
+    it('returns fine when matchMedia does not match', () => {
+      expect(getPrimary()).toBe<PointerModality>('fine');
+    });
+  });
+
+  // #endregion
+
+  // #region change subscription fires
+
+  describe('onPointerModalityChange — subscription', () => {
+    let fakeMql: FakeMql;
+    let getPrimary: typeof getPrimaryPointer;
+    let subscribe: typeof onPointerModalityChange;
+
+    beforeEach(async () => {
+      fakeMql = makeFakeMql(false); // start as fine
+      globalThis.matchMedia = vi.fn(() => fakeMql) as any;
+      const mod = await import('./pointer-modality?t=subscribe');
+      getPrimary = mod.getPrimaryPointer;
+      subscribe = mod.onPointerModalityChange;
+    });
+
+    afterEach(() => {
+      vi.resetModules();
+    });
+
+    it('callback fires with new modality when query changes', () => {
+      const received: PointerModality[] = [];
+      subscribe((m) => received.push(m));
+
+      // Initially fine
+      expect(getPrimary()).toBe('fine');
+
+      // Switch to coarse
+      fakeMql._fire(true);
+      expect(received).toEqual(['coarse']);
+
+      // Switch back to fine
+      fakeMql._fire(false);
+      expect(received).toEqual(['coarse', 'fine']);
+    });
+  });
+
+  // #endregion
+
+  // #region unsubscribe stops firing
+
+  describe('onPointerModalityChange — unsubscribe', () => {
+    let fakeMql: FakeMql;
+    let subscribe: typeof onPointerModalityChange;
+
+    beforeEach(async () => {
+      fakeMql = makeFakeMql(false);
+      globalThis.matchMedia = vi.fn(() => fakeMql) as any;
+      const mod = await import('./pointer-modality?t=unsub');
+      subscribe = mod.onPointerModalityChange;
+    });
+
+    afterEach(() => {
+      vi.resetModules();
+    });
+
+    it('callback no longer fires after unsubscribe', () => {
+      const received: PointerModality[] = [];
+      const unsub = subscribe((m) => received.push(m));
+
+      fakeMql._fire(true);
+      expect(received).toHaveLength(1);
+
+      unsub();
+      fakeMql._fire(false);
+      // Still only 1 item — callback stopped
+      expect(received).toHaveLength(1);
+    });
+
+    it('unsubscribe is idempotent — calling twice is safe', () => {
+      const unsub = subscribe(vi.fn());
+      expect(() => {
+        unsub();
+        unsub();
+      }).not.toThrow();
+    });
+  });
+
+  // #endregion
+
+  // #region no-matchMedia fallback
+
+  describe('getPrimaryPointer — no matchMedia (SSR / happy-dom fallback)', () => {
+    let getPrimary: typeof getPrimaryPointer;
+    let subscribe: typeof onPointerModalityChange;
+
+    let original: typeof globalThis.matchMedia;
+
+    beforeEach(async () => {
+      // Remove matchMedia entirely to simulate SSR. `_getMql()` reads
+      // `globalThis.matchMedia` lazily on every call, so it must stay absent
+      // for the duration of each test — restoring it here would make these
+      // assertions pass without ever touching the fallback path.
+      original = globalThis.matchMedia;
+      // @ts-expect-error intentional for SSR simulation
+      delete globalThis.matchMedia;
+      const mod = await import('./pointer-modality?t=ssr');
+      getPrimary = mod.getPrimaryPointer;
+      subscribe = mod.onPointerModalityChange;
+    });
+
+    afterEach(() => {
+      globalThis.matchMedia = original;
+      vi.resetModules();
+    });
+
+    it('returns fine as the safe default', () => {
+      expect(getPrimary()).toBe<PointerModality>('fine');
+    });
+
+    it('subscribe returns a no-op unsubscribe and never throws', () => {
+      const received: PointerModality[] = [];
+      const unsub = subscribe((m) => received.push(m));
+      expect(() => unsub()).not.toThrow();
+      expect(received).toHaveLength(0);
+    });
+  });
+
+  // #endregion
+});

--- a/libs/grid/src/lib/core/internal/pointer-modality.ts
+++ b/libs/grid/src/lib/core/internal/pointer-modality.ts
@@ -1,0 +1,119 @@
+/**
+ * Pointer modality detection — distinguishes coarse (touch/stylus) from fine
+ * (mouse/precision trackpad) input devices via the `pointer: coarse` media query.
+ *
+ * This module is **internal only** and is NOT exported from `src/public.ts`.
+ * Plugins and features use it to adapt hit-target sizing, long-press thresholds,
+ * and gesture disambiguation at runtime without querying the media each call.
+ *
+ * Design decisions:
+ * - A single `MediaQueryList` instance is shared across all subscribers to avoid
+ *   N OS-level listeners. Subscribers share one `change` handler.
+ * - Guards for missing `globalThis.matchMedia` keep the module SSR/happy-dom safe.
+ * - Legacy `addListener`/`removeListener` fallback for older Safari and happy-dom
+ *   environments that predate `MediaQueryList.addEventListener`.
+ *
+ * @since 3.5.0
+ * @internal
+ */
+
+// #region Types
+
+/**
+ * The resolved pointer category for the primary input device.
+ *
+ * - `'fine'`  — mouse or precision trackpad (pointer: fine).
+ * - `'coarse'` — touch screen or low-precision stylus (pointer: coarse).
+ *
+ * @since 3.5.0
+ */
+export type PointerModality = 'fine' | 'coarse';
+
+// #endregion
+
+// #region Singleton MQL + subscriber registry
+
+/** Lazily-created shared `MediaQueryList` for `(pointer: coarse)`. */
+let _mql: MediaQueryList | null = null;
+
+/** Active change subscribers. */
+const _subscribers = new Set<(m: PointerModality) => void>();
+
+/**
+ * Resolve the current modality from a `MediaQueryList` state.
+ * Returns `'coarse'` when the query matches, `'fine'` otherwise.
+ */
+function _resolve(mql: MediaQueryList): PointerModality {
+  return mql.matches ? 'coarse' : 'fine';
+}
+
+/**
+ * Shared MQL change handler — dispatches to all active subscribers.
+ */
+function _onMqlChange(e: MediaQueryListEvent): void {
+  const modality: PointerModality = e.matches ? 'coarse' : 'fine';
+  _subscribers.forEach((cb) => cb(modality));
+}
+
+/**
+ * Return (and lazily create) the shared MQL.
+ * Returns `null` in environments without `matchMedia` (SSR / happy-dom).
+ */
+function _getMql(): MediaQueryList | null {
+  if (_mql) return _mql;
+  if (typeof globalThis.matchMedia !== 'function') return null;
+  _mql = globalThis.matchMedia('(pointer: coarse)');
+  // Attach the single shared change handler via the modern or legacy API.
+  if (typeof _mql.addEventListener === 'function') {
+    _mql.addEventListener('change', _onMqlChange);
+  } else if (typeof (_mql as { addListener?: unknown }).addListener === 'function') {
+    // Legacy Safari / older environments
+    (_mql as { addListener: (cb: (e: MediaQueryListEvent) => void) => void }).addListener(_onMqlChange);
+  }
+  return _mql;
+}
+
+// #endregion
+
+// #region Public API
+
+/**
+ * Return the current pointer modality for the primary input device.
+ *
+ * Falls back to `'fine'` in SSR environments or browsers that do not
+ * support `matchMedia`.
+ *
+ * @since 3.5.0
+ */
+export function getPrimaryPointer(): PointerModality {
+  const mql = _getMql();
+  if (!mql) return 'fine';
+  return _resolve(mql);
+}
+
+/**
+ * Subscribe to pointer-modality changes.
+ *
+ * The callback fires whenever the browser detects a switch between fine and
+ * coarse primary input (e.g. user connects a mouse to a touch-screen device).
+ *
+ * Returns an **idempotent** unsubscribe function — calling it multiple times
+ * is safe.
+ *
+ * In SSR / environments without `matchMedia` the callback is never invoked
+ * and the returned unsubscribe is a no-op.
+ *
+ * @since 3.5.0
+ */
+export function onPointerModalityChange(cb: (m: PointerModality) => void): () => void {
+  _getMql(); // ensure MQL is created and the shared handler is attached
+  _subscribers.add(cb);
+  let removed = false;
+  return (): void => {
+    if (removed) return;
+    removed = true;
+    _subscribers.delete(cb);
+  };
+}
+
+// #endregion

--- a/libs/grid/src/lib/core/styles/base.css
+++ b/libs/grid/src/lib/core/styles/base.css
@@ -85,8 +85,16 @@
       display: flex;
       flex-direction: row;
       overflow: hidden;
-      /* Grid handles touch scrolling via JS (faux scrollbar pattern).
-         Prevent browser compositor from hijacking touch gestures mid-scroll. */
+      /* TOUCH-ACTION POLICY: The grid manages its own *scrolling* in JS (see
+         touch-scroll.ts + setupTouchScrollListeners) rather than delegating to the
+         browser compositor. Every element that would otherwise receive native touch
+         scroll, pan, or zoom must therefore declare touch-action: none, so the
+         compositor does not compete with or cancel the grid's handlers mid-gesture.
+         This policy covers scroll surfaces and JS-driven drag affordances only —
+         it is not a claim that every touch interaction in the grid is JS-managed.
+         MUST NOT use: pan-x pan-y (delegates scroll to browser, breaks faux scrollbar)
+         MUST NOT use: manipulation (suppresses double-tap-to-zoom, a WCAG violation).
+         touch-action: none is the only correct value for JS-managed scroll elements. */
       touch-action: none;
     }
 


### PR DESCRIPTION
Part of #302 (touch / pointer-input parity epic). **First PR in a stack of 5.**

Closes #307

## What

Adds the shared **pointer-modality** primitive the rest of the epic builds on, plus the user-facing touch guide.

- `libs/grid/src/lib/core/internal/pointer-modality.ts` — exports `getPrimaryPointer()` and `onPointerModalityChange()`, backed by a single module-level `MediaQueryList`. Plugins and features MUST use this rather than calling `matchMedia` directly.
- `base.css` — documents the grid's `touch-action` policy in one place.
- New docs page: **Touch input** guide (`grid/guides/touch-input`), cross-linked from the accessibility guide.
- `e2e/tests/touch-input.spec.ts` — scaffold with `hasTouch`/`isMobile` and a `touchDrag()` CDP helper the later PRs reuse.

The guide is written up-front for the whole epic, with `:::caution` markers on the sections that later PRs in the stack deliver. Each downstream PR flips its own marker as it ships.

## Testing

`bunx vitest run --root libs/grid` — 3772 pass, incl. 7 new `pointer-modality.spec.ts` tests. Lint 0 errors (203 warnings = repo baseline), build clean, bundle budgets pass.

> ⚠️ The e2e suite has **not** been executed (needs `bun nx serve demo-vanilla`). Tests guard with `test.skip()` when the demo lacks the feature.