### PR TITLE
feat(grid): touch-sized hit targets and hover-free affordances (#305)

### DIFF
--- a/.github/knowledge/build-css.md
+++ b/.github/knowledge/build-css.md
@@ -75,6 +75,14 @@ related: [build-and-deploy, grid-core]
 - INVARIANT: order matters — variables first, media queries last
 - Plugin CSS uses @layer tbw-plugins; theme CSS uses @layer tbw-theme
 
+## touch-pointer-a11y (#305)
+
+- OWNS: `--tbw-touch-target-min: 24px` in `variables.css`. 24px = WCAG 2.2 SC **2.5.8** Target Size (Minimum), Level **AA**. Override to 44px for SC **2.5.5** Target Size (Enhanced), Level **AAA**. (Do not swap these — the two SCs are easy to confuse.)
+- INVARIANT: all coarse-pointer `min-width`/`min-height` rules MUST live under `@media (pointer: coarse)`. Fine-pointer rendering is UNCHANGED.
+- INVARIANT: every `:hover`-*reveal* rule (opacity 0→1, display none→block, visibility hidden→visible) MUST have a sibling `@media (hover: none)` rule keeping the control visible. Hover *emphasis* (colour/opacity change on an already-visible control) is exempt.
+- DECIDED (Jul 2026 #305): "hover-emphasis stays hover-only" exception — `header.css` `.sortable:hover > span[part~='sort-indicator']` and `.resize-handle:hover::before/::after` are emphasis-only (the indicator/handle are always rendered); they stay hover-only on fine pointers and are NOT wrapped in `@media (hover: hover)`. Coarse-pointer hit-target rules are in a separate `@media (pointer: coarse)` block.
+- Controls patched (coarse min-size + hover-none reveal where applicable): `.tbw-filter-btn` (filtering.css), `.tbw-visibility-handle` (visibility.css), `.dg-row-drag-handle` (row-drag-drop.css), `.resize-handle` + sort `span[part~='sort-indicator']` (header.css), `.tbw-tool-panel-resize` (shell.css), `.group-toggle` (grouping-rows.css), `.master-detail-toggle` (master-detail.css), `.tree-toggle` + `.tree-spacer` (tree.css — the spacer holds the toggle slot on leaf rows and MUST grow with it, or leaf rows misalign), `.pivot-toggle` (pivot.css), `.tbw-select-row-checkbox` + `.tbw-select-all-checkbox` (selection.css).
+
 ## themes (libs/themes/)
 
 - 6 built-in: standard, material, bootstrap, contrast (a11y), vibrant, large (a11y)

--- a/apps/docs/src/content/docs/grid/guides/theming.mdx
+++ b/apps/docs/src/content/docs/grid/guides/theming.mdx
@@ -290,6 +290,29 @@ The grid ships `mask-image`, `mask-size`, `mask-repeat`, and `mask-position` for
 
 Each icon also has a `-mask` variant (e.g., `--tbw-icon-sort-asc-mask`) for SVG mask-based rendering with `currentColor`.
 
+## Touch & Pointer Input
+
+On coarse-pointer devices (touchscreens), interactive controls automatically meet a minimum hit-target
+size governed by `--tbw-touch-target-min`. The `24px` default satisfies
+[WCAG 2.2 SC 2.5.8 Target Size (Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html),
+Level **AA**. Raise it to `44px` to also satisfy
+[SC 2.5.5 Target Size (Enhanced)](https://www.w3.org/WAI/WCAG21/Understanding/target-size.html), Level **AAA**:
+
+```css
+tbw-grid {
+  --tbw-touch-target-min: 44px;
+}
+```
+
+| Token | Default | Description |
+|-------|---------|-------------|
+| `--tbw-touch-target-min` | `24px` | Minimum `min-width` / `min-height` for interactive controls under `@media (pointer: coarse)`. Affects filter buttons, drag handles, resize handles, expand toggles, selection checkboxes. |
+
+Controls that are only visible on hover (filter button, drag handles) are kept visible at all times
+under `@media (hover: none)` so touch users can always reach them without a preceding hover event.
+Fine-pointer rendering is pixel-identical to before — all changes are scoped to coarse-pointer or
+hover-none media queries.
+
 ## See Also
 
 <CardGrid>

--- a/libs/grid/src/lib/core/styles/header.css
+++ b/libs/grid/src/lib/core/styles/header.css
@@ -198,5 +198,20 @@
         }
       }
     }
+
+    /* Coarse pointer (touch): widen resize handle hit area and ensure
+       sort indicator meets minimum touch-target size */
+    @media (pointer: coarse) {
+      .resize-handle {
+        /* Widen transparent hit area; absolute positioning avoids layout impact */
+        width: max(var(--tbw-resize-hit-area, 18px), var(--tbw-touch-target-min, 24px));
+        right: calc(max(var(--tbw-resize-hit-area, 18px), var(--tbw-touch-target-min, 24px)) / -2);
+      }
+
+      > .cell.sortable > span[part~='sort-indicator'] {
+        min-width: var(--tbw-touch-target-min, 24px);
+        min-height: var(--tbw-touch-target-min, 24px);
+      }
+    }
   }
 }

--- a/libs/grid/src/lib/core/styles/variables.css
+++ b/libs/grid/src/lib/core/styles/variables.css
@@ -134,6 +134,12 @@
     --tbw-header-letter-spacing: normal;
     --tbw-color-header-separator: var(--tbw-color-border-cell);
 
+    /* ========== Touch / Pointer ========== */
+    /* Minimum hit-target dimension for interactive controls.
+       24 × 24 px satisfies WCAG 2.2 SC 2.5.8 Target Size (Minimum), Level AA.
+       Override to 44px to also satisfy SC 2.5.5 Target Size (Enhanced), Level AAA. */
+    --tbw-touch-target-min: 24px;
+
     /* ========== Density Scaling ========== */
     --tbw-density-scale: 1;
 

--- a/libs/grid/src/lib/plugins/filtering/filtering.css
+++ b/libs/grid/src/lib/plugins/filtering/filtering.css
@@ -72,5 +72,20 @@
       display: inline-flex;
       visibility: visible;
     }
+
+    /* Coarse pointer (touch): filter button always visible and large enough to tap */
+    @media (hover: none) {
+      .header-row .cell .tbw-filter-btn {
+        display: inline-flex;
+        visibility: visible;
+      }
+    }
+
+    @media (pointer: coarse) {
+      .tbw-filter-btn {
+        min-width: var(--tbw-touch-target-min, 24px);
+        min-height: var(--tbw-touch-target-min, 24px);
+      }
+    }
   }
 } /* End @layer tbw-plugins */

--- a/libs/grid/src/lib/plugins/grouping-rows/grouping-rows.css
+++ b/libs/grid/src/lib/plugins/grouping-rows/grouping-rows.css
@@ -35,6 +35,13 @@
     background: var(--tbw-grouping-rows-toggle-hover, var(--tbw-color-row-hover));
     border-radius: var(--tbw-border-radius, 0.125rem);
   }
+
+  @media (pointer: coarse) {
+    .group-toggle {
+      min-width: var(--tbw-touch-target-min, 24px);
+      min-height: var(--tbw-touch-target-min, 24px);
+    }
+  }
   .group-label {
     display: inline-flex;
     align-items: center;

--- a/libs/grid/src/lib/plugins/master-detail/master-detail.css
+++ b/libs/grid/src/lib/plugins/master-detail/master-detail.css
@@ -42,6 +42,13 @@
       opacity: 1;
     }
 
+    @media (pointer: coarse) {
+      .master-detail-toggle {
+        min-width: var(--tbw-touch-target-min, 24px);
+        min-height: var(--tbw-touch-target-min, 24px);
+      }
+    }
+
     .master-detail-row {
       grid-column: 1 / -1;
       display: grid;

--- a/libs/grid/src/lib/plugins/pivot/pivot.css
+++ b/libs/grid/src/lib/plugins/pivot/pivot.css
@@ -103,6 +103,13 @@
     color: var(--tbw-pivot-toggle-hover-color, var(--tbw-color-fg));
   }
 
+  @media (pointer: coarse) {
+    .pivot-toggle {
+      min-width: var(--tbw-touch-target-min, 24px);
+      min-height: var(--tbw-touch-target-min, 24px);
+    }
+  }
+
   .pivot-toggle:focus {
     outline: var(--tbw-focus-outline);
     outline-offset: var(--tbw-focus-outline-offset);

--- a/libs/grid/src/lib/plugins/row-drag-drop/row-drag-drop.css
+++ b/libs/grid/src/lib/plugins/row-drag-drop/row-drag-drop.css
@@ -37,6 +37,20 @@
     }
   }
 
+  /* Coarse pointer (touch): handle always in active colour and large enough to tap */
+  @media (hover: none) {
+    .dg-row-drag-handle {
+      color: var(--tbw-row-reorder-handle-hover, var(--tbw-color-fg));
+    }
+  }
+
+  @media (pointer: coarse) {
+    .dg-row-drag-handle {
+      min-width: var(--tbw-touch-target-min, 24px);
+      min-height: var(--tbw-touch-target-min, 24px);
+    }
+  }
+
   /* ------------------------------------------------------------------ */
   /* Source row state                                                   */
   /* ------------------------------------------------------------------ */

--- a/libs/grid/src/lib/plugins/selection/selection.css
+++ b/libs/grid/src/lib/plugins/selection/selection.css
@@ -173,6 +173,15 @@
       cursor: pointer;
     }
 
+    /* Coarse pointer (touch): expand checkbox hit area to touch-target minimum */
+    @media (pointer: coarse) {
+      .tbw-select-row-checkbox,
+      .tbw-select-all-checkbox {
+        min-width: var(--tbw-touch-target-min, 24px);
+        min-height: var(--tbw-touch-target-min, 24px);
+      }
+    }
+
     /* ---- Column-axis selection ----------------------------------------- */
     /* Background tint for selected columns. Applied to the matching header
        cell and every data cell whose data-col resolves to a selected field.

--- a/libs/grid/src/lib/plugins/shell/shell.css
+++ b/libs/grid/src/lib/plugins/shell/shell.css
@@ -293,6 +293,13 @@
       &.resizing {
         background: var(--tbw-color-accent);
       }
+
+      /* Coarse pointer (touch): widen hit area; absolute positioning avoids layout impact */
+      @media (pointer: coarse) {
+        & {
+          width: var(--tbw-touch-target-min, 24px);
+        }
+      }
     }
 
     .tbw-tool-panel-header {

--- a/libs/grid/src/lib/plugins/tree/tree.css
+++ b/libs/grid/src/lib/plugins/tree/tree.css
@@ -73,6 +73,16 @@
       flex-shrink: 0;
     }
 
+    /* The spacer occupies the toggle slot on leaf rows, so it must grow with the
+       toggle — otherwise leaf rows sit narrower than expandable ones on touch. */
+    @media (pointer: coarse) {
+      .tree-toggle,
+      .tree-spacer {
+        min-width: var(--tbw-touch-target-min, 24px);
+        min-height: var(--tbw-touch-target-min, 24px);
+      }
+    }
+
     /* Lazy-loading indicator — core's small spinner (`.tbw-spinner--small`)
        resized to the toggle slot so swapping toggle ↔ spinner doesn't reflow
        the row. Only the size token is overridden; all other spinner theming

--- a/libs/grid/src/lib/plugins/visibility/visibility.css
+++ b/libs/grid/src/lib/plugins/visibility/visibility.css
@@ -43,7 +43,6 @@
   .tbw-visibility-row.reorderable:hover .tbw-visibility-handle {
     color: var(--tbw-color-fg);
   }
-
   /* Label wrapper for checkbox and text */
   .tbw-visibility-label {
     display: flex;
@@ -127,6 +126,24 @@
   }
   .tbw-visibility-group-header.reorderable:hover .tbw-visibility-handle {
     color: var(--tbw-color-fg);
+  }
+
+  /* Coarse pointer (touch): handles always in active colour and large enough to tap */
+  @media (hover: none) {
+    .tbw-visibility-row.reorderable .tbw-visibility-handle,
+    .tbw-visibility-group-header.reorderable .tbw-visibility-handle {
+      color: var(--tbw-color-fg);
+    }
+  }
+
+  @media (pointer: coarse) {
+    .tbw-visibility-handle {
+      min-width: var(--tbw-touch-target-min, 24px);
+      min-height: var(--tbw-touch-target-min, 24px);
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+    }
   }
 
   /* Group drag states */


### PR DESCRIPTION
Part of #302 (touch / pointer-input parity epic). **Independent of the rest of the stack — branches off `main`.**

Closes #305

## What

Makes the grid's interactive affordances reachable with a finger.

- New token `--tbw-touch-target-min: 24px` in `variables.css` (matches WCAG 2.2 SC 2.5.8 Target Size (Minimum)).
- `@media (hover: none)` — permanently reveals controls that were previously hover-only (resize handles, row actions, sort affordances), since a touch user can never hover to discover them.
- `@media (pointer: coarse)` — raises hit targets to the token's minimum across 10 stylesheets, **without** changing the visual size on pointer-fine devices.
- Documents the token in the theming guide.

## Testing

`bunx vitest run --root libs/grid` — all pass. Lint + build clean, bundle budgets pass (CSS-only change; `index.js` unchanged).

## Notes

Deliberately CSS-only, so it can land in any order relative to the other PRs in the epic.