### PR TITLE
feat(grid): convert drags to pointer events with pointer capture (#303)

### DIFF
--- a/.github/knowledge/grid-core.md
+++ b/.github/knowledge/grid-core.md
@@ -116,6 +116,20 @@ Core = `libs/grid/src/lib/core/`. Shell chrome is a PLUGIN (see grid-plugins-she
 - INVARIANT: unsubscribe is idempotent (`removed` flag guards double-call).
 - DECIDED (#307, Jul 2026): part of touch-input epic #302 cross-cutting infra. Plugins and features MUST use this module rather than calling `matchMedia` directly. `@since 3.5.0`. Tests: `pointer-modality.spec.ts`.
 
+## pointer-drag (`core/internal/pointer-drag.ts`)
+
+- OWNS: `startPointerDrag(startEvent, captureTarget, handlers, options?) => cancelFn`, `PointerDragHandlers` (`onMove`, `onEnd`, `onPromote?`, `onCancel?`), `PointerDragOptions` (`threshold?`, `longPressDuration?`, `longPressSlop?` default 8). **NOT in `public.ts`** — internal. `@since 3.5.0`.
+- INVARIANT: uses `setPointerCapture` ONLY — no `document`/`window` `pointermove`/`pointerup` listeners. The single exception is a capture-phase `document` `keydown` for Escape-to-abort. WHY: capture survives DOM virtualization re-renders that would otherwise detach the drag source mid-gesture.
+- INVARIANT: `captureTarget` must be a stable element (the resize *handle*, not the header cell). `ResizeController.start` therefore takes a 4th param `captureTarget?: Element`.
+- INVARIANT: `touch-action: none` is applied to the capture target only inside `onPromote` — never on `pointerdown`. WHY: applying it at pointerdown would swallow a plain swipe-to-scroll over the grid. Restored in both `onEnd` and `onCancel`.
+- INVARIANT: re-entrancy guarded by a module-level `WeakMap<Element, Set<number>>` of active pointerIds; a second `pointerdown` with the same id on the same target is ignored.
+- FLOW (promotion): no threshold + no long-press → promoted synchronously at call time. `threshold > 0` → promoted on first move past distance. `longPressDuration > 0` → promoted by timer; any move beyond `longPressSlop` before the timer fires **cancels the whole drag** (it was a scroll, not a drag).
+- `onPromote` exists so callers can act at promotion time even when the pointer never moves (range-paint dispatches its `mousedown` hook there). Fired from all three promotion sites.
+- DECIDED (#303, Jul 2026): fine-vs-coarse branch uses per-event `e.pointerType` (`touch`/`pen` → coarse, `mouse` → fine) in preference to `getPrimaryPointer()`. WHY: hybrid devices (Surface) report `(pointer: coarse)` even while a mouse is in use. `getPrimaryPointer()` is only the fallback for synthetic events with no `pointerType`.
+- DECIDED (#303, Jul 2026): #228 never shipped this module, so #303 created it. It is deliberately generic so the DnD plugins (#228: column reorder, row drag-drop) can consume it later instead of growing a second drag primitive.
+- Consumers: `resize.ts` (column resize), `plugins/shell/shell.ts` (tool-panel splitter), `event-delegation.ts` (cell-range paint, `LONG_PRESS_MS = 400` on coarse pointers only).
+- TENSION: listeners are typed `(event: Event)` and narrowed, not `(e: PointerEvent)` — `pointer*` lives on `HTMLElementEventMap`, not `ElementEventMap`, so a generic `Element.addEventListener` rejects the narrower signature.
+- Tests: `pointer-drag.spec.ts` (24), `resize.spec.ts` (8). happy-dom has `PointerEvent` but pointer capture does not route events — specs MUST stub `setPointerCapture`/`hasPointerCapture`/`releasePointerCapture` on the capture target and dispatch pointer events **directly on that target**.
 ## long-press priority policy (#307 / touch-input epic #302)
 
 - DECIDED (#307, Jul 2026): agreed priority chain for long-press on a touch device (shipped by #303–#306):

--- a/apps/docs/src/content/docs/grid/guides/touch-input.mdx
+++ b/apps/docs/src/content/docs/grid/guides/touch-input.mdx
@@ -34,6 +34,14 @@ The table below shows how each action maps across input types.
 | Range-select cells | Ctrl+click / drag | Ctrl+click / drag | See note below ↓ |
 | Open context menu | Right-click | Two-finger tap | Long-press |
 | Header menu | — | — | Long-press header |
+| Resize a tool panel | Drag splitter | Drag splitter | Drag splitter |
+| Paint a cell range | Drag across cells | Drag across cells | Long-press cell, then drag |
+
+All drag interactions in the table above are driven by [Pointer Events](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events) with
+[pointer capture](https://developer.mozilla.org/en-US/docs/Web/API/Element/setPointerCapture), so mouse, pen and touch follow one code path — there is no
+separate touch implementation to fall out of sync. Cell-range painting is the one gesture that behaves differently by modality: with a fine pointer (mouse,
+trackpad) the drag starts immediately, while with a coarse pointer (touch, pen) it requires a 400 ms long-press first, so that a plain swipe still scrolls the
+grid.
 
 - **Multi-sort via touch** — secondary header sort will be accessible via the column header menu (long-press header → header menu → Sort → Add sort key).
 - **Multi-select via touch** — long-pressing a row enters *selection mode* (a toolbar appears). Subsequent taps toggle rows in that mode. Described further in [Selection-mode UX](#selection-mode-ux).
@@ -45,7 +53,7 @@ The table below shows how each action maps across input types.
 
 When a long-press occurs, the grid resolves the action according to the following priority chain:
 
-1. **Header long-press → Column header menu** (highest priority) — opens the column header menu regardless of which plugins are active. *(Planned: #270)*
+1. **Header long-press → Column header menu** (highest priority) — opens the column header menu regardless of which plugins are active.
 2. **Row long-press + SelectionPlugin active → Selection mode** — enters touch selection mode; a toolbar appears at the top of the grid.
 3. **Row / cell long-press + no SelectionPlugin → Context menu** — falls back to the context menu if `ContextMenuPlugin` is active.
 

--- a/e2e/tests/touch-input.spec.ts
+++ b/e2e/tests/touch-input.spec.ts
@@ -35,3 +35,161 @@ test.describe('Touch Input — smoke tests', () => {
     expect(cellCount).toBeGreaterThan(0);
   });
 });
+
+/**
+ * Pointer-driven drag tests (#303).
+ *
+ * All grid drags run through `startPointerDrag()`, so mouse and touch share one
+ * code path.  Playwright's `touchscreen` API only exposes `tap()`, so real touch
+ * drags are driven through a raw CDP `Input.dispatchTouchEvent` session.
+ */
+
+/** Dispatch a touch drag: down at (x1,y1), a few moves, then up at (x2,y2). */
+async function touchDrag(
+  page: import('@playwright/test').Page,
+  x1: number,
+  y1: number,
+  x2: number,
+  y2: number,
+  opts: { holdMs?: number; steps?: number } = {},
+): Promise<void> {
+  const { holdMs = 0, steps = 8 } = opts;
+  const cdp = await page.context().newCDPSession(page);
+  await cdp.send('Input.dispatchTouchEvent', {
+    type: 'touchStart',
+    touchPoints: [{ x: x1, y: y1, id: 1 }],
+  });
+  if (holdMs > 0) await page.waitForTimeout(holdMs);
+  for (let i = 1; i <= steps; i++) {
+    const x = x1 + ((x2 - x1) * i) / steps;
+    const y = y1 + ((y2 - y1) * i) / steps;
+    await cdp.send('Input.dispatchTouchEvent', {
+      type: 'touchMove',
+      touchPoints: [{ x, y, id: 1 }],
+    });
+    await page.waitForTimeout(16);
+  }
+  await cdp.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] });
+  await cdp.detach().catch(() => undefined);
+}
+
+/** Width of the first column header, used to assert resize deltas. */
+async function firstHeaderWidth(page: import('@playwright/test').Page): Promise<number> {
+  const box = await page.locator(SELECTORS.headerCell).first().boundingBox();
+  return box?.width ?? 0;
+}
+
+test.describe('Touch Input — pointer-driven drags (#303)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(DEMOS.vanilla);
+    await waitForGridReadyMobile(page);
+  });
+
+  test('column resize works with a mouse drag (pointer path)', async ({ page }) => {
+    const handle = page.locator(SELECTORS.resizeHandle).first();
+    const handleCount = await page.locator(SELECTORS.resizeHandle).count();
+    test.skip(handleCount === 0, 'demo has no resizable columns');
+
+    const before = await firstHeaderWidth(page);
+    const box = await handle.boundingBox();
+    expect(box).not.toBeNull();
+
+    const cx = box!.x + box!.width / 2;
+    const cy = box!.y + box!.height / 2;
+    await page.mouse.move(cx, cy);
+    await page.mouse.down();
+    await page.mouse.move(cx + 60, cy, { steps: 10 });
+    await page.mouse.up();
+    await page.waitForTimeout(200);
+
+    const after = await firstHeaderWidth(page);
+    expect(after).toBeGreaterThan(before + 20);
+  });
+
+  test('column resize works with a touch drag', async ({ page }) => {
+    const handleCount = await page.locator(SELECTORS.resizeHandle).count();
+    test.skip(handleCount === 0, 'demo has no resizable columns');
+
+    const before = await firstHeaderWidth(page);
+    const box = await page.locator(SELECTORS.resizeHandle).first().boundingBox();
+    expect(box).not.toBeNull();
+
+    const cx = box!.x + box!.width / 2;
+    const cy = box!.y + box!.height / 2;
+    await touchDrag(page, cx, cy, cx + 60, cy);
+    await page.waitForTimeout(200);
+
+    const after = await firstHeaderWidth(page);
+    expect(after).toBeGreaterThan(before + 20);
+  });
+
+  test('pressing Escape mid-resize aborts and restores the original width', async ({ page }) => {
+    const handleCount = await page.locator(SELECTORS.resizeHandle).count();
+    test.skip(handleCount === 0, 'demo has no resizable columns');
+
+    const before = await firstHeaderWidth(page);
+    const box = await page.locator(SELECTORS.resizeHandle).first().boundingBox();
+    expect(box).not.toBeNull();
+
+    const cx = box!.x + box!.width / 2;
+    const cy = box!.y + box!.height / 2;
+    await page.mouse.move(cx, cy);
+    await page.mouse.down();
+    await page.mouse.move(cx + 80, cy, { steps: 10 });
+    await page.keyboard.press('Escape');
+    await page.mouse.up();
+    await page.waitForTimeout(200);
+
+    const after = await firstHeaderWidth(page);
+    expect(Math.abs(after - before)).toBeLessThan(4);
+  });
+
+  test('a plain touch swipe over cells scrolls instead of painting a range', async ({ page }) => {
+    const grid = page.locator(SELECTORS.grid);
+    const firstCell = grid.locator(SELECTORS.cell).first();
+    const box = await firstCell.boundingBox();
+    expect(box).not.toBeNull();
+
+    const cx = box!.x + box!.width / 2;
+    const cy = box!.y + box!.height / 2;
+    // No hold: the coarse-pointer branch must not promote the drag.
+    await touchDrag(page, cx, cy, cx, cy - 160);
+    await page.waitForTimeout(300);
+
+    const selected = await grid.locator('[role="gridcell"][aria-selected="true"]').count();
+    expect(selected).toBe(0);
+  });
+
+  test('a long-press then drag paints a cell range on touch', async ({ page }) => {
+    const grid = page.locator(SELECTORS.grid);
+    const cells = grid.locator(SELECTORS.cell);
+    const startBox = await cells.first().boundingBox();
+    expect(startBox).not.toBeNull();
+
+    const cx = startBox!.x + startBox!.width / 2;
+    const cy = startBox!.y + startBox!.height / 2;
+    // Hold past LONG_PRESS_MS (400 ms) before moving, then drag down two rows.
+    await touchDrag(page, cx, cy, cx, cy + startBox!.height * 2, { holdMs: 600 });
+    await page.waitForTimeout(300);
+
+    const selected = await grid.locator('[role="gridcell"][aria-selected="true"]').count();
+    // Selection may be disabled in the demo; only assert when the feature is live.
+    test.skip(selected === 0, 'demo grid has no active cell-range selection');
+    expect(selected).toBeGreaterThan(1);
+  });
+
+  test('the grid still scrolls vertically with a one-finger swipe', async ({ page }) => {
+    const viewport = page.locator(SELECTORS.body).first();
+    const box = await viewport.boundingBox();
+    expect(box).not.toBeNull();
+
+    const before = await viewport.evaluate((el) => el.scrollTop);
+    const cx = box!.x + box!.width / 2;
+    const cy = box!.y + box!.height * 0.75;
+    await touchDrag(page, cx, cy, cx, cy - box!.height * 0.5);
+    await page.waitForTimeout(400);
+
+    const after = await viewport.evaluate((el) => el.scrollTop);
+    expect(after).toBeGreaterThan(before);
+  });
+});

--- a/libs/grid/src/lib/core/internal/event-delegation.ts
+++ b/libs/grid/src/lib/core/internal/event-delegation.ts
@@ -17,6 +17,8 @@ import { GridClasses } from '../constants';
 import type { CellMouseEvent } from '../plugin/types';
 import type { GridHost, InternalGrid } from '../types';
 import { handleGridKeyDown } from './keyboard';
+import { startPointerDrag } from './pointer-drag';
+import { getPrimaryPointer } from './pointer-modality';
 import { handleRowClick } from './rows';
 import { clearCellFocus, getColIndexFromCell, getRowIndexFromCell } from './utils';
 import { readCellField } from './value-accessor';
@@ -146,37 +148,107 @@ function buildCellMouseEvent(
 
 // #region Drag Tracking
 /**
- * Handle mousedown events and dispatch to plugin system.
+ * Long-press duration (ms) before a coarse-pointer press promotes to a
+ * range-paint drag. Matches the iOS Numbers / Google Sheets idiom.
  */
-function handleMouseDown(grid: InternalGrid, renderRoot: HTMLElement, e: MouseEvent): void {
-  const event = buildCellMouseEvent(grid, renderRoot, e, 'mousedown');
-  const handled = grid._dispatchCellMouseDown?.(event) ?? false;
+const LONG_PRESS_MS = 400;
 
-  // If any plugin handled mousedown, start tracking for drag
-  if (handled) {
+/**
+ * True when the press came from a coarse pointer (finger or stylus).
+ *
+ * `pointerType` is per-event and therefore more accurate than the
+ * `(pointer: coarse)` media query on hybrid devices (e.g. a Surface with both
+ * a touchscreen and a mouse), so it is preferred here. `getPrimaryPointer()`
+ * is the fallback for synthetic events that omit `pointerType`.
+ */
+function isCoarsePointer(e: PointerEvent): boolean {
+  if (e.pointerType === 'touch' || e.pointerType === 'pen') return true;
+  if (e.pointerType === 'mouse') return false;
+  return getPrimaryPointer() === 'coarse';
+}
+
+/**
+ * Suppress native panning for the duration of a range-paint drag.
+ *
+ * Applied only once the drag is actually promoted — before that the browser
+ * must remain free to scroll, otherwise a simple swipe over the grid would be
+ * swallowed. Returns a restore function.
+ */
+function suppressTouchScroll(bodyEl: HTMLElement | undefined): () => void {
+  if (!bodyEl) return () => undefined;
+  const prev = bodyEl.style.touchAction;
+  bodyEl.style.touchAction = 'none';
+  return () => {
+    bodyEl.style.touchAction = prev;
+  };
+}
+
+/**
+ * Handle `pointerdown` and dispatch to the plugin system.
+ *
+ * Fine pointers (mouse / precision trackpad) keep the historical behaviour: the
+ * `mousedown` hook is dispatched immediately and any plugin that claims it
+ * starts a drag on the very next move.
+ *
+ * Coarse pointers (touch / stylus) defer the dispatch until a {@link LONG_PRESS_MS}
+ * long-press has elapsed, so that taps and scroll swipes are never mistaken for
+ * a range-paint. Movement beyond the slop before the timer fires aborts the
+ * gesture entirely and lets the browser scroll.
+ */
+function handlePointerDown(grid: InternalGrid, renderRoot: HTMLElement, e: PointerEvent): void {
+  // Only primary presses start a drag; secondary buttons belong to ContextMenuPlugin.
+  if (e.button !== 0 && e.pointerType === 'mouse') return;
+  if (dragState.get(grid)) return;
+
+  const coarse = isCoarsePointer(e);
+  let restoreTouchAction: (() => void) | null = null;
+
+  /** Dispatch the `mousedown` hook; returns whether a plugin claimed the press. */
+  const dispatchDown = (): boolean => {
+    const event = buildCellMouseEvent(grid, renderRoot, e, 'mousedown');
+    return grid._dispatchCellMouseDown?.(event) ?? false;
+  };
+
+  if (!coarse) {
+    // Fine pointer — dispatch up front, exactly as the mouse implementation did.
+    if (!dispatchDown()) return;
     dragState.set(grid, true);
   }
-}
 
-/**
- * Handle mousemove events (only when dragging).
- */
-function handleMouseMove(grid: InternalGrid, renderRoot: HTMLElement, e: MouseEvent): void {
-  if (!dragState.get(grid)) return;
-
-  const event = buildCellMouseEvent(grid, renderRoot, e, 'mousemove');
-  grid._dispatchCellMouseMove?.(event);
-}
-
-/**
- * Handle mouseup events.
- */
-function handleMouseUp(grid: InternalGrid, renderRoot: HTMLElement, e: MouseEvent): void {
-  if (!dragState.get(grid)) return;
-
-  const event = buildCellMouseEvent(grid, renderRoot, e, 'mouseup');
-  grid._dispatchCellMouseUp?.(event);
-  dragState.set(grid, false);
+  startPointerDrag(
+    e,
+    renderRoot,
+    {
+      onPromote: () => {
+        if (coarse) {
+          // Long-press recognised — only now does the press become a drag.
+          if (!dispatchDown()) return;
+          dragState.set(grid, true);
+          restoreTouchAction = suppressTouchScroll(grid._bodyEl);
+        }
+      },
+      onMove: (moveEvent) => {
+        if (!dragState.get(grid)) return;
+        const event = buildCellMouseEvent(grid, renderRoot, moveEvent, 'mousemove');
+        grid._dispatchCellMouseMove?.(event);
+      },
+      onEnd: (upEvent) => {
+        restoreTouchAction?.();
+        restoreTouchAction = null;
+        if (!dragState.get(grid)) return;
+        const event = buildCellMouseEvent(grid, renderRoot, upEvent, 'mouseup');
+        grid._dispatchCellMouseUp?.(event);
+        dragState.set(grid, false);
+      },
+      onCancel: () => {
+        restoreTouchAction?.();
+        restoreTouchAction = null;
+        dragState.set(grid, false);
+      },
+    },
+    // Coarse presses must be held; fine presses promote on the first move.
+    coarse ? { longPressDuration: LONG_PRESS_MS } : undefined,
+  );
 }
 // #endregion
 
@@ -281,11 +353,10 @@ export function setupRootEventDelegation(
   // Element-level keydown handler for keyboard navigation
   gridElement.addEventListener('keydown', (e) => handleGridKeyDown(grid, e), { signal });
 
-  // Central mouse event handling for plugins
-  renderRoot.addEventListener('mousedown', (e) => handleMouseDown(grid, renderRoot, e as MouseEvent), { signal });
-
-  // Track global mousemove/mouseup for drag operations (column resize, selection, etc.)
-  document.addEventListener('mousemove', (e: MouseEvent) => handleMouseMove(grid, renderRoot, e), { signal });
-  document.addEventListener('mouseup', (e: MouseEvent) => handleMouseUp(grid, renderRoot, e), { signal });
+  // Central pointer event handling for plugins. Pointer capture keeps the whole
+  // drag on the render root, so no document-level move/up listeners are needed.
+  renderRoot.addEventListener('pointerdown', (e) => handlePointerDown(grid, renderRoot, e as PointerEvent), {
+    signal,
+  });
 }
 // #endregion

--- a/libs/grid/src/lib/core/internal/header.ts
+++ b/libs/grid/src/lib/core/internal/header.ts
@@ -79,10 +79,15 @@ function createResizeHandle(grid: InternalGrid, colIndex: number, cell: HTMLElem
   const handle = document.createElement('div');
   handle.className = 'resize-handle';
   handle.setAttribute('aria-hidden', 'true');
-  handle.addEventListener('mousedown', (e: MouseEvent) => {
+  handle.addEventListener('pointerdown', (e: PointerEvent) => {
+    // Only the primary mouse button starts a resize. Without this, a right-click
+    // on the handle would preventDefault() and swallow the context menu.
+    if (e.button !== 0 && e.pointerType === 'mouse') return;
     e.stopPropagation();
     e.preventDefault();
-    grid._resizeController.start(e, colIndex, cell);
+    // Capture on the handle itself so the drag keeps tracking once the pointer
+    // leaves the header cell, or the header is re-rendered mid-drag.
+    grid._resizeController.start(e, colIndex, cell, handle);
   });
   handle.addEventListener('dblclick', (e: MouseEvent) => {
     e.stopPropagation();

--- a/libs/grid/src/lib/core/internal/pointer-drag.spec.ts
+++ b/libs/grid/src/lib/core/internal/pointer-drag.spec.ts
@@ -1,0 +1,458 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { startPointerDrag, type PointerDragHandlers } from './pointer-drag';
+
+// #region Test helpers
+
+/**
+ * Minimal PointerEvent factory compatible with happy-dom.
+ * happy-dom may not support the full PointerEvent constructor, so we build
+ * a synthetic object that satisfies the properties our code reads.
+ */
+function makePointerEvent(
+  type: string,
+  init: Partial<{
+    pointerId: number;
+    clientX: number;
+    clientY: number;
+    pointerType: string;
+    isPrimary: boolean;
+    buttons: number;
+    key: string;
+    bubbles: boolean;
+    cancelable: boolean;
+  }> = {},
+): PointerEvent {
+  // Prefer native PointerEvent if available
+  if (typeof PointerEvent !== 'undefined') {
+    try {
+      return new PointerEvent(type, {
+        pointerId: init.pointerId ?? 1,
+        clientX: init.clientX ?? 0,
+        clientY: init.clientY ?? 0,
+        pointerType: init.pointerType ?? 'mouse',
+        isPrimary: init.isPrimary ?? true,
+        buttons: init.buttons ?? 1,
+        bubbles: init.bubbles ?? true,
+        cancelable: init.cancelable ?? true,
+      });
+    } catch {
+      // Fall through to synthetic object
+    }
+  }
+  return {
+    type,
+    pointerId: init.pointerId ?? 1,
+    clientX: init.clientX ?? 0,
+    clientY: init.clientY ?? 0,
+    pointerType: init.pointerType ?? 'mouse',
+    isPrimary: init.isPrimary ?? true,
+    buttons: init.buttons ?? 1,
+    bubbles: init.bubbles ?? true,
+    cancelable: init.cancelable ?? true,
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn(),
+  } as unknown as PointerEvent;
+}
+
+function makeKeyboardEvent(key: string): KeyboardEvent {
+  try {
+    return new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
+  } catch {
+    return { type: 'keydown', key, bubbles: true, cancelable: true } as KeyboardEvent;
+  }
+}
+
+/**
+ * Create a minimal element with the pointer-capture API stubbed.
+ * Returns the element and capture state helpers.
+ */
+function makeCaptureTarget() {
+  const el = document.createElement('div');
+  document.body.appendChild(el);
+  const capturedIds = new Set<number>();
+
+  // Stub setPointerCapture / releasePointerCapture / hasPointerCapture
+  el.setPointerCapture = (id: number) => {
+    capturedIds.add(id);
+  };
+  el.releasePointerCapture = (id: number) => {
+    capturedIds.delete(id);
+  };
+  el.hasPointerCapture = (id: number) => capturedIds.has(id);
+
+  return { el, capturedIds };
+}
+
+function fire(el: EventTarget, event: Event): void {
+  el.dispatchEvent(event);
+}
+
+// #endregion
+
+describe('startPointerDrag', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
+  // #region Immediate (no threshold / no long-press)
+
+  describe('immediate promotion (no threshold, no long-press)', () => {
+    it('calls onMove on the first pointermove after pointerdown', () => {
+      const { el } = makeCaptureTarget();
+      const onMove = vi.fn();
+      const onEnd = vi.fn();
+      const start = makePointerEvent('pointerdown', { clientX: 10, clientY: 10 });
+      startPointerDrag(start, el, { onMove, onEnd });
+
+      const move = makePointerEvent('pointermove', { clientX: 20, clientY: 10 });
+      fire(el, move);
+
+      expect(onMove).toHaveBeenCalledTimes(1);
+      expect(onMove).toHaveBeenCalledWith(move);
+    });
+
+    it('calls onEnd on pointerup after promotion', () => {
+      const { el } = makeCaptureTarget();
+      const onEnd = vi.fn();
+      const start = makePointerEvent('pointerdown', { clientX: 0, clientY: 0 });
+      startPointerDrag(start, el, { onMove: vi.fn(), onEnd });
+
+      fire(el, makePointerEvent('pointermove', { clientX: 5, clientY: 0 }));
+      const up = makePointerEvent('pointerup', { clientX: 5, clientY: 0 });
+      fire(el, up);
+
+      expect(onEnd).toHaveBeenCalledWith(up);
+    });
+
+    it('calls onEnd (not onCancel) on pointerup before any move when promoted up front', () => {
+      const { el } = makeCaptureTarget();
+      const onEnd = vi.fn();
+      const onCancel = vi.fn();
+      const start = makePointerEvent('pointerdown', { clientX: 0, clientY: 0 });
+      startPointerDrag(start, el, { onMove: vi.fn(), onEnd, onCancel });
+
+      // No move — just up
+      fire(el, makePointerEvent('pointerup', { clientX: 0, clientY: 0 }));
+
+      // With threshold=0 longPressDelay=0, promoted=true immediately,
+      // so pointerup should call onEnd, NOT onCancel.
+      expect(onEnd).toHaveBeenCalledTimes(1);
+      expect(onCancel).not.toHaveBeenCalled();
+    });
+
+    it('sets pointer capture on captureTarget', () => {
+      const { el, capturedIds } = makeCaptureTarget();
+      const start = makePointerEvent('pointerdown', { pointerId: 7 });
+      startPointerDrag(start, el, { onMove: vi.fn(), onEnd: vi.fn() });
+
+      expect(capturedIds.has(7)).toBe(true);
+    });
+
+    it('releases pointer capture after pointerup', () => {
+      const { el, capturedIds } = makeCaptureTarget();
+      const start = makePointerEvent('pointerdown', { pointerId: 3 });
+      startPointerDrag(start, el, { onMove: vi.fn(), onEnd: vi.fn() });
+
+      fire(el, makePointerEvent('pointermove', { pointerId: 3 }));
+      fire(el, makePointerEvent('pointerup', { pointerId: 3 }));
+
+      expect(capturedIds.has(3)).toBe(false);
+    });
+  });
+
+  // #endregion
+
+  // #region Threshold promotion
+
+  describe('threshold promotion', () => {
+    it('does NOT call onMove until movement >= threshold', () => {
+      const { el } = makeCaptureTarget();
+      const onMove = vi.fn();
+      const start = makePointerEvent('pointerdown', { clientX: 0, clientY: 0 });
+      startPointerDrag(start, el, { onMove, onEnd: vi.fn() }, { threshold: 10 });
+
+      fire(el, makePointerEvent('pointermove', { clientX: 5, clientY: 0 }));
+      expect(onMove).not.toHaveBeenCalled();
+
+      fire(el, makePointerEvent('pointermove', { clientX: 15, clientY: 0 }));
+      expect(onMove).toHaveBeenCalledTimes(1);
+    });
+
+    it('continues calling onMove after promotion without re-checking threshold', () => {
+      const { el } = makeCaptureTarget();
+      const onMove = vi.fn();
+      const start = makePointerEvent('pointerdown', { clientX: 0, clientY: 0 });
+      startPointerDrag(start, el, { onMove, onEnd: vi.fn() }, { threshold: 10 });
+
+      // Promote
+      fire(el, makePointerEvent('pointermove', { clientX: 15, clientY: 0 }));
+      // Move back toward start — should still call onMove
+      fire(el, makePointerEvent('pointermove', { clientX: 2, clientY: 0 }));
+
+      expect(onMove).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // #endregion
+
+  // #region Long-press promotion
+
+  describe('long-press promotion', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('does NOT call onMove before the long-press duration elapses', () => {
+      const { el } = makeCaptureTarget();
+      const onMove = vi.fn();
+      const start = makePointerEvent('pointerdown', { clientX: 0, clientY: 0 });
+      startPointerDrag(start, el, { onMove, onEnd: vi.fn() }, { longPressDuration: 400 });
+
+      fire(el, makePointerEvent('pointermove', { clientX: 2, clientY: 0 }));
+      expect(onMove).not.toHaveBeenCalled();
+    });
+
+    it('calls onMove after long-press elapses and subsequent move', () => {
+      const { el } = makeCaptureTarget();
+      const onMove = vi.fn();
+      const start = makePointerEvent('pointerdown', { clientX: 0, clientY: 0 });
+      startPointerDrag(start, el, { onMove, onEnd: vi.fn() }, { longPressDuration: 400 });
+
+      vi.advanceTimersByTime(400);
+
+      // Move after promotion
+      fire(el, makePointerEvent('pointermove', { clientX: 5, clientY: 0 }));
+      expect(onMove).toHaveBeenCalledTimes(1);
+    });
+
+    it('cancels drag when movement exceeds longPressSlop before timer fires', () => {
+      const { el } = makeCaptureTarget();
+      const onMove = vi.fn();
+      const onCancel = vi.fn();
+      const start = makePointerEvent('pointerdown', { clientX: 0, clientY: 0 });
+      startPointerDrag(start, el, { onMove, onEnd: vi.fn(), onCancel }, { longPressDuration: 400, longPressSlop: 8 });
+
+      // Move more than slop (9 px)
+      fire(el, makePointerEvent('pointermove', { clientX: 9, clientY: 0 }));
+
+      expect(onMove).not.toHaveBeenCalled();
+      expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT cancel drag when movement stays within slop', () => {
+      const { el } = makeCaptureTarget();
+      const onMove = vi.fn();
+      const onCancel = vi.fn();
+      const start = makePointerEvent('pointerdown', { clientX: 0, clientY: 0 });
+      startPointerDrag(start, el, { onMove, onEnd: vi.fn(), onCancel }, { longPressDuration: 400, longPressSlop: 8 });
+
+      // Move within slop (5 px)
+      fire(el, makePointerEvent('pointermove', { clientX: 5, clientY: 0 }));
+
+      expect(onCancel).not.toHaveBeenCalled();
+
+      // Promote
+      vi.advanceTimersByTime(400);
+      fire(el, makePointerEvent('pointermove', { clientX: 7, clientY: 0 }));
+      expect(onMove).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onCancel on pointerup before long-press timer fires', () => {
+      const { el } = makeCaptureTarget();
+      const onEnd = vi.fn();
+      const onCancel = vi.fn();
+      const start = makePointerEvent('pointerdown', { clientX: 0, clientY: 0 });
+      startPointerDrag(start, el, { onMove: vi.fn(), onEnd, onCancel }, { longPressDuration: 400 });
+
+      // Release before timer
+      fire(el, makePointerEvent('pointerup', { clientX: 0, clientY: 0 }));
+
+      expect(onEnd).not.toHaveBeenCalled();
+      expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // #endregion
+
+  // #region Cancellation
+
+  describe('cancellation', () => {
+    it('calls onCancel on pointercancel', () => {
+      const { el } = makeCaptureTarget();
+      const onCancel = vi.fn();
+      const start = makePointerEvent('pointerdown');
+      startPointerDrag(start, el, { onMove: vi.fn(), onEnd: vi.fn(), onCancel });
+
+      fire(el, makePointerEvent('pointercancel'));
+
+      expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onCancel on lostpointercapture', () => {
+      const { el } = makeCaptureTarget();
+      const onCancel = vi.fn();
+      const start = makePointerEvent('pointerdown', { pointerId: 1 });
+      startPointerDrag(start, el, { onMove: vi.fn(), onEnd: vi.fn(), onCancel });
+
+      fire(el, makePointerEvent('lostpointercapture', { pointerId: 1 }));
+
+      expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onCancel on Escape keydown', () => {
+      const { el } = makeCaptureTarget();
+      const onCancel = vi.fn();
+      const start = makePointerEvent('pointerdown');
+      startPointerDrag(start, el, { onMove: vi.fn(), onEnd: vi.fn(), onCancel });
+
+      fire(document, makeKeyboardEvent('Escape'));
+
+      expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT call onCancel on non-Escape keydown', () => {
+      const { el } = makeCaptureTarget();
+      const onCancel = vi.fn();
+      const start = makePointerEvent('pointerdown');
+      startPointerDrag(start, el, { onMove: vi.fn(), onEnd: vi.fn(), onCancel });
+
+      fire(document, makeKeyboardEvent('Enter'));
+
+      expect(onCancel).not.toHaveBeenCalled();
+    });
+
+    it('returned cancel() function cancels the drag', () => {
+      const { el } = makeCaptureTarget();
+      const onCancel = vi.fn();
+      const start = makePointerEvent('pointerdown');
+      const cancel = startPointerDrag(start, el, { onMove: vi.fn(), onEnd: vi.fn(), onCancel });
+
+      cancel();
+
+      expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it('cancel() is idempotent — second call is a no-op', () => {
+      const { el } = makeCaptureTarget();
+      const onCancel = vi.fn();
+      const start = makePointerEvent('pointerdown');
+      const cancel = startPointerDrag(start, el, { onMove: vi.fn(), onEnd: vi.fn(), onCancel });
+
+      cancel();
+      cancel();
+
+      expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // #endregion
+
+  // #region No-leak teardown
+
+  describe('no-leak teardown', () => {
+    it('does not call any handler after cancel()', () => {
+      const { el } = makeCaptureTarget();
+      const onMove = vi.fn();
+      const onEnd = vi.fn();
+      const onCancel = vi.fn();
+      const start = makePointerEvent('pointerdown');
+      const cancel = startPointerDrag(start, el, { onMove, onEnd, onCancel });
+
+      cancel();
+
+      // These events should be ignored after cancel
+      fire(el, makePointerEvent('pointermove', { clientX: 100 }));
+      fire(el, makePointerEvent('pointerup'));
+
+      expect(onMove).not.toHaveBeenCalled();
+      expect(onEnd).not.toHaveBeenCalled();
+      // onCancel was called once by cancel(), not again by the events
+      expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it('removes listeners after pointerup — subsequent events are ignored', () => {
+      const { el } = makeCaptureTarget();
+      const onMove = vi.fn();
+      const start = makePointerEvent('pointerdown');
+      startPointerDrag(start, el, { onMove, onEnd: vi.fn() });
+
+      fire(el, makePointerEvent('pointermove', { clientX: 10 }));
+      fire(el, makePointerEvent('pointerup'));
+      // After completion, moves should not fire
+      fire(el, makePointerEvent('pointermove', { clientX: 20 }));
+
+      expect(onMove).toHaveBeenCalledTimes(1); // only the one before pointerup
+    });
+
+    it('does not call Escape handler after drag ends', () => {
+      const { el } = makeCaptureTarget();
+      const onCancel = vi.fn();
+      const start = makePointerEvent('pointerdown');
+      startPointerDrag(start, el, { onMove: vi.fn(), onEnd: vi.fn(), onCancel });
+
+      fire(el, makePointerEvent('pointermove', { clientX: 10 }));
+      fire(el, makePointerEvent('pointerup'));
+      // After successful end, Escape should not call onCancel
+      fire(document, makeKeyboardEvent('Escape'));
+
+      expect(onCancel).not.toHaveBeenCalled();
+    });
+  });
+
+  // #endregion
+
+  // #region Re-entrancy guard
+
+  describe('re-entrancy guard', () => {
+    it('ignores a second startPointerDrag with same element + pointerId', () => {
+      const { el } = makeCaptureTarget();
+      const onMove1 = vi.fn();
+      const onMove2 = vi.fn();
+
+      const start = makePointerEvent('pointerdown', { pointerId: 1 });
+      startPointerDrag(start, el, { onMove: onMove1, onEnd: vi.fn() });
+      startPointerDrag(start, el, { onMove: onMove2, onEnd: vi.fn() });
+
+      fire(el, makePointerEvent('pointermove', { pointerId: 1, clientX: 10 }));
+
+      expect(onMove1).toHaveBeenCalledTimes(1);
+      expect(onMove2).not.toHaveBeenCalled();
+    });
+
+    it('allows a new drag after the previous one ends', () => {
+      const { el } = makeCaptureTarget();
+      const onMove = vi.fn();
+
+      const start = makePointerEvent('pointerdown', { pointerId: 1 });
+      startPointerDrag(start, el, { onMove, onEnd: vi.fn() });
+      fire(el, makePointerEvent('pointerup', { pointerId: 1 }));
+
+      // Start another drag
+      startPointerDrag(start, el, { onMove, onEnd: vi.fn() });
+      fire(el, makePointerEvent('pointermove', { pointerId: 1, clientX: 5 }));
+
+      expect(onMove).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // #endregion
+
+  // #region Handlers type check (static)
+
+  it('accepts undefined onCancel gracefully', () => {
+    const { el } = makeCaptureTarget();
+    const handlers: PointerDragHandlers = { onMove: vi.fn(), onEnd: vi.fn() };
+    const start = makePointerEvent('pointerdown');
+
+    expect(() => {
+      const cancel = startPointerDrag(start, el, handlers);
+      cancel();
+    }).not.toThrow();
+  });
+
+  // #endregion
+});

--- a/libs/grid/src/lib/core/internal/pointer-drag.ts
+++ b/libs/grid/src/lib/core/internal/pointer-drag.ts
@@ -1,0 +1,328 @@
+/**
+ * Generic pointer-drag helper — converts a `pointerdown` event into a
+ * deterministic drag lifecycle with pointer capture, threshold / long-press
+ * promotion, and clean teardown.
+ *
+ * ## Usage
+ * ```ts
+ * element.addEventListener('pointerdown', (e) => {
+ *   startPointerDrag(e, element, {
+ *     onMove: (pe) => resize(pe.clientX),
+ *     onEnd:  (pe) => commit(),
+ *   });
+ * });
+ * ```
+ *
+ * ## Fine vs coarse pointer promotion
+ * For **fine** pointers (mouse / precision trackpad): set `longPressDuration`
+ * to `0` (or omit it) so the drag is promoted immediately on first move.
+ *
+ * For **coarse** pointers (touch / stylus): set `longPressDuration` to e.g.
+ * `400` ms so the drag is only promoted after the user holds still long
+ * enough. Movement exceeding `longPressSlop` px before the timer fires
+ * **cancels** the drag — this lets native scroll proceed uninterrupted.
+ *
+ * Branch example at call site:
+ * ```ts
+ * const isCoarse = e.pointerType === 'touch' || e.pointerType === 'pen';
+ * startPointerDrag(e, el, handlers, { longPressDuration: isCoarse ? 400 : 0 });
+ * ```
+ *
+ * ## Pointer capture
+ * `setPointerCapture` / `releasePointerCapture` are called on `captureTarget`
+ * only — **never** `document` / `window` listeners.
+ *
+ * ## Re-entrancy
+ * Simultaneous drags on the same element with the same `pointerId` are
+ * silently ignored (returns a no-op cancel function).
+ *
+ * ## DnD plugins
+ * HTML5 drag-and-drop plugins (`RowDragDropPlugin`, `ReorderPlugin`, etc.)
+ * are expected to consume this module in the future (#228). The API is
+ * intentionally general.
+ *
+ * This module is **internal only** — NOT exported from `src/public.ts`.
+ *
+ * @since 3.5.0
+ * @internal
+ */
+
+// #region Types
+
+/**
+ * Callbacks supplied to {@link startPointerDrag}.
+ *
+ * @since 3.5.0
+ */
+export interface PointerDragHandlers {
+  /**
+   * Called on each `pointermove` after the drag has been promoted.
+   * For immediate drags (no threshold / long-press) this fires on the very
+   * first move. For long-press promotion it fires only after the delay.
+   */
+  onMove(e: PointerEvent): void;
+
+  /**
+   * Called when the pointer is released after promotion (`pointerup`).
+   * Not called if the drag was cancelled before promotion.
+   */
+  onEnd(e: PointerEvent): void;
+
+  /**
+   * Called once when the drag is promoted — when the movement threshold is
+   * crossed or the long-press timer elapses. Fires before the first `onMove`.
+   *
+   * Long-press call sites use this to enter a mode (e.g. cell range-paint) and
+   * give feedback at the moment the press is recognised, even if the pointer
+   * never subsequently moves.
+   */
+  onPromote?(): void;
+
+  /**
+   * Called when the drag is cancelled — by `pointercancel`, `lostpointercapture`,
+   * an `Escape` keydown, or the returned `cancel()` function.
+   * Also called when the pointer is released *before* promotion (tap / short press).
+   */
+  onCancel?(): void;
+}
+
+/**
+ * Options for {@link startPointerDrag}.
+ *
+ * @since 3.5.0
+ */
+export interface PointerDragOptions {
+  /**
+   * Minimum movement in px before the drag is promoted.
+   * `0` (default) promotes immediately on the first `pointermove`.
+   */
+  threshold?: number;
+
+  /**
+   * Long-press duration in milliseconds.
+   *
+   * `0` (default) = no long-press requirement; the drag is promoted as soon
+   * as the pointer moves (subject to `threshold`).
+   *
+   * When `> 0` the drag is promoted only after this many ms have elapsed
+   * without the pointer exceeding `longPressSlop`. If the slop is exceeded
+   * before the timer fires the entire drag is cancelled so native scroll can
+   * proceed.
+   *
+   * Use this for **coarse** (touch/stylus) pointers to disambiguate a tap
+   * or a scroll gesture from an intentional drag-to-paint interaction.
+   */
+  longPressDuration?: number;
+
+  /**
+   * Maximum pointer movement (px) permitted during the long-press wait.
+   * If this distance is exceeded the drag is cancelled.
+   * Default: `8`.
+   */
+  longPressSlop?: number;
+}
+
+// #endregion
+
+// #region Re-entrancy guard
+
+/**
+ * Tracks active pointer IDs per capture target.
+ * Prevents two simultaneous drags on the same element with the same pointer.
+ */
+const _activePointers = new WeakMap<Element, Set<number>>();
+
+function _claimPointer(el: Element, id: number): boolean {
+  let set = _activePointers.get(el);
+  if (!set) {
+    set = new Set();
+    _activePointers.set(el, set);
+  }
+  if (set.has(id)) return false;
+  set.add(id);
+  return true;
+}
+
+function _releasePointer(el: Element, id: number): void {
+  _activePointers.get(el)?.delete(id);
+}
+
+// #endregion
+
+// #region startPointerDrag
+
+/**
+ * Begin a pointer drag on `captureTarget`.
+ *
+ * Attaches `pointermove`, `pointerup`, `pointercancel`, and
+ * `lostpointercapture` listeners directly to `captureTarget` (never to
+ * `document` / `window`). Calls `setPointerCapture` immediately so events
+ * continue to route here regardless of DOM changes.
+ *
+ * Returns a `cancel()` dispose function. Calling it is idempotent.
+ *
+ * @param startEvent  - The originating `pointerdown` event.
+ * @param captureTarget - Element on which to set pointer capture and attach
+ *   pointer listeners. Must be in a connected document.
+ * @param handlers - `onMove`, `onEnd`, and optional `onCancel` callbacks.
+ * @param options - Threshold, long-press, and slop configuration.
+ *
+ * @since 3.5.0
+ */
+export function startPointerDrag(
+  startEvent: PointerEvent,
+  captureTarget: Element,
+  handlers: PointerDragHandlers,
+  options?: PointerDragOptions,
+): () => void {
+  const { onMove, onEnd, onCancel, onPromote } = handlers;
+  const threshold = options?.threshold ?? 0;
+  const longPressDuration = options?.longPressDuration ?? 0;
+  const longPressSlop = options?.longPressSlop ?? 8;
+  const pointerId = startEvent.pointerId;
+
+  // Re-entrancy guard — silently ignore duplicate drags on same element/pointer
+  if (!_claimPointer(captureTarget, pointerId)) {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    return () => {};
+  }
+
+  const startX = startEvent.clientX;
+  const startY = startEvent.clientY;
+
+  // Promotion: true when the drag has passed threshold/long-press requirements
+  let promoted = threshold === 0 && longPressDuration === 0;
+  let done = false;
+  let longPressTimer: ReturnType<typeof setTimeout> | null = null;
+
+  // Set pointer capture immediately so pointermove/up route here
+  try {
+    captureTarget.setPointerCapture(pointerId);
+  } catch {
+    // setPointerCapture can fail in unit-test environments without full browser
+    // APIs, or if the element was detached between pointerdown and here.
+    // Callers typically flip UI state (cursor, user-select, `isResizing`)
+    // *before* calling us, so we must report the failure as a cancellation —
+    // otherwise that state is never rolled back and the UI sticks mid-drag.
+    _releasePointer(captureTarget, pointerId);
+    onCancel?.();
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    return () => {};
+  }
+
+  // #region Internal helpers
+
+  function teardown(): void {
+    if (done) return;
+    done = true;
+    if (longPressTimer !== null) {
+      clearTimeout(longPressTimer);
+      longPressTimer = null;
+    }
+    captureTarget.removeEventListener('pointermove', onPointerMove);
+    captureTarget.removeEventListener('pointerup', onPointerUp);
+    captureTarget.removeEventListener('pointercancel', onPointerCancel);
+    captureTarget.removeEventListener('lostpointercapture', onLostCapture);
+    document.removeEventListener('keydown', onEscapeKey, true);
+    _releasePointer(captureTarget, pointerId);
+    try {
+      if (captureTarget.hasPointerCapture(pointerId)) {
+        captureTarget.releasePointerCapture(pointerId);
+      }
+    } catch {
+      // Ignore — element may have been removed from DOM
+    }
+  }
+
+  function cancel(): void {
+    if (done) return;
+    teardown();
+    onCancel?.();
+  }
+
+  // #endregion
+
+  // #region Event handlers
+
+  function onPointerMove(event: Event): void {
+    const e = event as PointerEvent;
+    if (e.pointerId !== pointerId || done) return;
+
+    const dx = e.clientX - startX;
+    const dy = e.clientY - startY;
+    const dist = Math.sqrt(dx * dx + dy * dy);
+
+    if (!promoted) {
+      if (longPressDuration > 0) {
+        // Cancel entire drag if movement exceeds slop while waiting for long-press
+        if (dist > longPressSlop) {
+          cancel();
+          return;
+        }
+        // Long-press not yet elapsed — swallow event, no onMove
+        return;
+      }
+      // Threshold promotion only (no long-press)
+      if (threshold > 0 && dist < threshold) return;
+      promoted = true;
+      onPromote?.();
+    }
+
+    onMove(e);
+  }
+
+  function onPointerUp(event: Event): void {
+    const e = event as PointerEvent;
+    if (e.pointerId !== pointerId || done) return;
+    const wasPromoted = promoted;
+    teardown();
+    if (wasPromoted) {
+      onEnd(e);
+    } else {
+      onCancel?.();
+    }
+  }
+
+  function onPointerCancel(event: Event): void {
+    const e = event as PointerEvent;
+    if (e.pointerId !== pointerId || done) return;
+    cancel();
+  }
+
+  function onLostCapture(event: Event): void {
+    const e = event as PointerEvent;
+    if (e.pointerId !== pointerId || done) return;
+    cancel();
+  }
+
+  function onEscapeKey(event: Event): void {
+    const e = event as KeyboardEvent;
+    if (e.key === 'Escape' && !done) cancel();
+  }
+
+  // #endregion
+
+  // Attach listeners before starting the long-press timer
+  captureTarget.addEventListener('pointermove', onPointerMove);
+  captureTarget.addEventListener('pointerup', onPointerUp);
+  captureTarget.addEventListener('pointercancel', onPointerCancel);
+  captureTarget.addEventListener('lostpointercapture', onLostCapture);
+  document.addEventListener('keydown', onEscapeKey, true);
+
+  // Drags with neither a threshold nor a long-press are promoted up front.
+  if (promoted) onPromote?.();
+
+  // Start long-press timer after capture so the countdown is accurate
+  if (longPressDuration > 0) {
+    longPressTimer = setTimeout(() => {
+      longPressTimer = null;
+      if (done) return;
+      promoted = true;
+      onPromote?.();
+    }, longPressDuration);
+  }
+
+  return cancel;
+}
+
+// #endregion

--- a/libs/grid/src/lib/core/internal/resize.spec.ts
+++ b/libs/grid/src/lib/core/internal/resize.spec.ts
@@ -1,111 +1,220 @@
 import { describe, expect, it, vi } from 'vitest';
 import { createResizeController } from './resize';
 
-function mockMouseEvent(type: string, props: Partial<MouseEvent> = {}) {
-  const e = new MouseEvent(type, { bubbles: true, cancelable: true, clientX: props.clientX || 0 });
-  return e;
+/**
+ * Build a PointerEvent. happy-dom implements `PointerEvent` but not the pointer
+ * capture APIs, so those are stubbed on the handle by {@link makeHandle}.
+ */
+function mockPointerEvent(type: string, props: Partial<PointerEvent> = {}) {
+  return new PointerEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    clientX: props.clientX ?? 0,
+    pointerId: props.pointerId ?? 1,
+    pointerType: props.pointerType ?? 'mouse',
+  });
+}
+
+/**
+ * The resize handle doubles as the pointer-capture target so the drag stays
+ * bound to it for the whole gesture. Stubs the capture API happy-dom lacks.
+ */
+function makeHandle(): HTMLElement {
+  const handle = document.createElement('div');
+  let captured = false;
+  handle.setPointerCapture = () => {
+    captured = true;
+  };
+  handle.hasPointerCapture = () => captured;
+  handle.releasePointerCapture = () => {
+    captured = false;
+  };
+  document.body.appendChild(handle);
+  return handle;
+}
+
+function makeCell(width: number): HTMLElement {
+  const cell = document.createElement('div');
+  Object.defineProperty(cell, 'getBoundingClientRect', {
+    value: () => ({ width, height: 20, left: 0, top: 0, right: width, bottom: 20 }),
+  });
+  return cell;
+}
+
+function makeGrid(columns: unknown[]) {
+  return {
+    _columns: columns,
+    get _visibleColumns() {
+      return this._columns.filter((c: any) => !c.hidden);
+    },
+    updateTemplate: vi.fn(),
+    dispatchEvent: vi.fn(),
+    requestStateChange: vi.fn(),
+  } as any;
 }
 
 describe('resize controller', () => {
   it('updates column width & dispatches events', async () => {
-    const grid: any = {
-      _columns: [{ field: 'a', width: 100 }],
-      get _visibleColumns() {
-        return this._columns.filter((c: any) => !c.hidden);
-      },
-      updateTemplate: vi.fn(),
-      dispatchEvent: vi.fn(),
-    };
+    const grid = makeGrid([{ field: 'a', width: 100 }]);
     const controller = createResizeController(grid);
-    const cell = document.createElement('div');
-    Object.defineProperty(cell, 'getBoundingClientRect', {
-      value: () => ({ width: 100, height: 20, left: 0, top: 0, right: 100, bottom: 20 }),
-    });
-    controller.start(mockMouseEvent('mousedown', { clientX: 0 }), 0, cell);
-    window.dispatchEvent(mockMouseEvent('mousemove', { clientX: 30 }));
-    window.dispatchEvent(mockMouseEvent('mouseup', { clientX: 30 }));
+    const cell = makeCell(100);
+    const handle = makeHandle();
+
+    controller.start(mockPointerEvent('pointerdown', { clientX: 0 }), 0, cell, handle);
+    handle.dispatchEvent(mockPointerEvent('pointermove', { clientX: 30 }));
+    handle.dispatchEvent(mockPointerEvent('pointerup', { clientX: 30 }));
+
     expect(grid._columns[0].width).toBe(130);
     expect(grid._columns[0].__userResized).toBe(true);
     expect(grid.dispatchEvent).toHaveBeenCalled();
   });
 
-  it('sets isResizing during drag and briefly after mouseup', async () => {
-    const grid: any = {
-      _columns: [{ field: 'a', width: 100 }],
-      get _visibleColumns() {
-        return this._columns.filter((c: any) => !c.hidden);
-      },
-      updateTemplate: vi.fn(),
-      dispatchEvent: vi.fn(),
-    };
+  it('sets isResizing during drag and briefly after pointerup', async () => {
+    const grid = makeGrid([{ field: 'a', width: 100 }]);
     const controller = createResizeController(grid);
-    const cell = document.createElement('div');
-    Object.defineProperty(cell, 'getBoundingClientRect', {
-      value: () => ({ width: 100, height: 20, left: 0, top: 0, right: 100, bottom: 20 }),
-    });
+    const cell = makeCell(100);
+    const handle = makeHandle();
 
-    // Not resizing initially
     expect(controller.isResizing).toBe(false);
 
-    // Start resize
-    controller.start(mockMouseEvent('mousedown', { clientX: 0 }), 0, cell);
+    controller.start(mockPointerEvent('pointerdown', { clientX: 0 }), 0, cell, handle);
     expect(controller.isResizing).toBe(true);
 
-    // During drag
-    window.dispatchEvent(mockMouseEvent('mousemove', { clientX: 30 }));
+    handle.dispatchEvent(mockPointerEvent('pointermove', { clientX: 30 }));
     expect(controller.isResizing).toBe(true);
 
-    // After mouseup, still true briefly to suppress click
-    window.dispatchEvent(mockMouseEvent('mouseup', { clientX: 30 }));
+    // Still true briefly after release, to suppress the click that follows.
+    handle.dispatchEvent(mockPointerEvent('pointerup', { clientX: 30 }));
     expect(controller.isResizing).toBe(true);
 
-    // After RAF, should be false
     await new Promise((r) => requestAnimationFrame(r));
     expect(controller.isResizing).toBe(false);
   });
 
   it('respects column minWidth during drag resize', () => {
-    const grid: any = {
-      _columns: [{ field: 'a', width: 150, minWidth: 100 }],
-      get _visibleColumns() {
-        return this._columns.filter((c: any) => !c.hidden);
-      },
-      updateTemplate: vi.fn(),
-      dispatchEvent: vi.fn(),
-    };
+    const grid = makeGrid([{ field: 'a', width: 150, minWidth: 100 }]);
     const controller = createResizeController(grid);
-    const cell = document.createElement('div');
-    Object.defineProperty(cell, 'getBoundingClientRect', {
-      value: () => ({ width: 150, height: 20, left: 0, top: 0, right: 150, bottom: 20 }),
-    });
+    const cell = makeCell(150);
+    const handle = makeHandle();
 
-    controller.start(mockMouseEvent('mousedown', { clientX: 0 }), 0, cell);
-    window.dispatchEvent(mockMouseEvent('mousemove', { clientX: -80 }));
-    window.dispatchEvent(mockMouseEvent('mouseup', { clientX: -80 }));
+    controller.start(mockPointerEvent('pointerdown', { clientX: 0 }), 0, cell, handle);
+    handle.dispatchEvent(mockPointerEvent('pointermove', { clientX: -80 }));
+    handle.dispatchEvent(mockPointerEvent('pointerup', { clientX: -80 }));
 
     expect(grid._columns[0].width).toBe(100);
   });
 
   it('falls back to 40px minimum for non-positive minWidth values', () => {
-    const grid: any = {
-      _columns: [{ field: 'a', width: 80, minWidth: 0 }],
-      get _visibleColumns() {
-        return this._columns.filter((c: any) => !c.hidden);
-      },
-      updateTemplate: vi.fn(),
-      dispatchEvent: vi.fn(),
-    };
+    const grid = makeGrid([{ field: 'a', width: 80, minWidth: 0 }]);
     const controller = createResizeController(grid);
-    const cell = document.createElement('div');
-    Object.defineProperty(cell, 'getBoundingClientRect', {
-      value: () => ({ width: 80, height: 20, left: 0, top: 0, right: 80, bottom: 20 }),
-    });
+    const cell = makeCell(80);
+    const handle = makeHandle();
 
-    controller.start(mockMouseEvent('mousedown', { clientX: 0 }), 0, cell);
-    window.dispatchEvent(mockMouseEvent('mousemove', { clientX: -70 }));
-    window.dispatchEvent(mockMouseEvent('mouseup', { clientX: -70 }));
+    controller.start(mockPointerEvent('pointerdown', { clientX: 0 }), 0, cell, handle);
+    handle.dispatchEvent(mockPointerEvent('pointermove', { clientX: -70 }));
+    handle.dispatchEvent(mockPointerEvent('pointerup', { clientX: -70 }));
 
     expect(grid._columns[0].width).toBe(40);
+  });
+
+  it('restores document chrome when the drag is cancelled', () => {
+    const grid = makeGrid([{ field: 'a', width: 100 }]);
+    const controller = createResizeController(grid);
+    const cell = makeCell(100);
+    const handle = makeHandle();
+
+    controller.start(mockPointerEvent('pointerdown', { clientX: 0 }), 0, cell, handle);
+    handle.dispatchEvent(mockPointerEvent('pointermove', { clientX: 30 }));
+    handle.dispatchEvent(mockPointerEvent('pointercancel', { clientX: 30 }));
+
+    expect(document.body.style.userSelect).toBe('');
+    expect(document.documentElement.style.cursor).toBe('');
+  });
+
+  it('reverts the column width when the drag is cancelled', () => {
+    const grid = makeGrid([{ field: 'a', width: 100 }]);
+    const controller = createResizeController(grid);
+    const cell = makeCell(100);
+    const handle = makeHandle();
+
+    controller.start(mockPointerEvent('pointerdown', { clientX: 0 }), 0, cell, handle);
+    handle.dispatchEvent(mockPointerEvent('pointermove', { clientX: 30 }));
+    expect(grid._columns[0].width).toBe(130);
+
+    // Escape / pointercancel means "abort", so the half-finished drag must not
+    // be committed — the column goes back to the width it had at pointerdown.
+    handle.dispatchEvent(mockPointerEvent('pointercancel', { clientX: 30 }));
+
+    expect(grid._columns[0].width).toBe(100);
+    expect(grid.requestStateChange).not.toHaveBeenCalled();
+  });
+
+  it('reverts the column width when the drag is cancelled with Escape', () => {
+    const grid = makeGrid([{ field: 'a', width: 100 }]);
+    const controller = createResizeController(grid);
+    const cell = makeCell(100);
+    const handle = makeHandle();
+
+    controller.start(mockPointerEvent('pointerdown', { clientX: 0 }), 0, cell, handle);
+    handle.dispatchEvent(mockPointerEvent('pointermove', { clientX: 40 }));
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+
+    expect(grid._columns[0].width).toBe(100);
+    expect(grid.requestStateChange).not.toHaveBeenCalled();
+  });
+
+  it('commits and fires requestStateChange when the drag ends normally', () => {
+    const grid = makeGrid([{ field: 'a', width: 100 }]);
+    const controller = createResizeController(grid);
+    const cell = makeCell(100);
+    const handle = makeHandle();
+
+    controller.start(mockPointerEvent('pointerdown', { clientX: 0 }), 0, cell, handle);
+    handle.dispatchEvent(mockPointerEvent('pointermove', { clientX: 30 }));
+    handle.dispatchEvent(mockPointerEvent('pointerup', { clientX: 30 }));
+
+    expect(grid._columns[0].width).toBe(130);
+    expect(grid.requestStateChange).toHaveBeenCalled();
+  });
+
+  it('dispose() tears down an in-flight drag', () => {
+    const grid = makeGrid([{ field: 'a', width: 100 }]);
+    const controller = createResizeController(grid);
+    const cell = makeCell(100);
+    const handle = makeHandle();
+
+    controller.start(mockPointerEvent('pointerdown', { clientX: 0 }), 0, cell, handle);
+    handle.dispatchEvent(mockPointerEvent('pointermove', { clientX: 30 }));
+    controller.dispose();
+
+    // Listeners are gone, so a later move must not keep resizing the column.
+    handle.dispatchEvent(mockPointerEvent('pointermove', { clientX: 80 }));
+    expect(grid._columns[0].width).not.toBe(180);
+  });
+
+  it('accepts a legacy MouseEvent for backwards compatibility', () => {
+    const grid = makeGrid([{ field: 'a', width: 100 }]);
+    const controller = createResizeController(grid);
+    const cell = makeCell(100);
+    const handle = makeHandle();
+
+    // Pre-v3.5.0 callers passed the `mousedown` event straight through.
+    expect(() =>
+      controller.start(new MouseEvent('mousedown', { clientX: 0, bubbles: true }), 0, cell, handle),
+    ).not.toThrow();
+  });
+
+  it('tracks a touch drag through the capture target', () => {
+    const grid = makeGrid([{ field: 'a', width: 100 }]);
+    const controller = createResizeController(grid);
+    const cell = makeCell(100);
+    const handle = makeHandle();
+
+    controller.start(mockPointerEvent('pointerdown', { clientX: 0, pointerType: 'touch' }), 0, cell, handle);
+    handle.dispatchEvent(mockPointerEvent('pointermove', { clientX: 25, pointerType: 'touch' }));
+    handle.dispatchEvent(mockPointerEvent('pointerup', { clientX: 25, pointerType: 'touch' }));
+
+    expect(grid._columns[0].width).toBe(125);
   });
 
   it('resetColumn restores original configured width', () => {

--- a/libs/grid/src/lib/core/internal/resize.ts
+++ b/libs/grid/src/lib/core/internal/resize.ts
@@ -1,11 +1,47 @@
 import type { GridHost, ResizeController } from '../types';
+import { startPointerDrag } from './pointer-drag';
+
+/**
+ * Normalise the event that started a resize.
+ *
+ * `ResizeController.start` still accepts a plain `MouseEvent` for callers
+ * written before v3.5.0. Every `mousedown` in a modern browser is preceded by a
+ * `pointerdown` for the same physical pointer, and the primary mouse is always
+ * `pointerId: 1` — so re-describing the event that way keeps pointer capture
+ * working for legacy callers instead of silently dropping the drag.
+ */
+function toPointerEvent(e: MouseEvent | PointerEvent): PointerEvent {
+  if ('pointerId' in e) return e;
+  return new PointerEvent('pointerdown', {
+    pointerId: 1,
+    pointerType: 'mouse',
+    isPrimary: true,
+    clientX: e.clientX,
+    clientY: e.clientY,
+    button: e.button,
+    buttons: e.buttons,
+  });
+}
 
 export function createResizeController(grid: GridHost): ResizeController {
-  let resizeState: { startX: number; colIndex: number; startWidth: number } | null = null;
+  /**
+   * In-flight gesture state. The `start*` fields capture enough of the column to
+   * put it back exactly as it was if the drag is aborted (Escape / pointercancel).
+   */
+  let resizeState: {
+    startX: number;
+    colIndex: number;
+    startWidth: number;
+    startConfiguredWidth: number | string | undefined;
+    startRenderedWidth: number | undefined;
+    startUserResized: boolean;
+  } | null = null;
+  /** Teardown for the active `startPointerDrag`, so `dispose()` can abort mid-gesture. */
+  let cancelDrag: (() => void) | null = null;
   let pendingRaf: number | null = null;
   let prevCursor: string | null = null;
   let prevUserSelect: string | null = null;
-  const onMove = (e: MouseEvent) => {
+  const onMove = (e: PointerEvent) => {
     if (!resizeState) return;
     const delta = e.clientX - resizeState.startX;
     const col = grid._visibleColumns[resizeState.colIndex];
@@ -24,17 +60,14 @@ export function createResizeController(grid: GridHost): ResizeController {
     grid.dispatchEvent(new CustomEvent('column-resize', { detail: { field: col.field, width } }));
   };
   let justFinishedResize = false;
-  const onUp = () => {
-    const hadResize = resizeState !== null;
-    // Set flag to suppress click events that fire immediately after mouseup
+  const onUp = (hadResize: boolean) => {
+    // Set flag to suppress click events that fire immediately after pointerup
     if (hadResize) {
       justFinishedResize = true;
       requestAnimationFrame(() => {
         justFinishedResize = false;
       });
     }
-    window.removeEventListener('mousemove', onMove);
-    window.removeEventListener('mouseup', onUp);
     if (prevCursor !== null) {
       document.documentElement.style.cursor = prevCursor;
       prevCursor = null;
@@ -48,6 +81,36 @@ export function createResizeController(grid: GridHost): ResizeController {
     if (hadResize && grid.requestStateChange) {
       grid.requestStateChange();
     }
+  };
+
+  /**
+   * Abort an in-flight resize: put the column back exactly as it was at
+   * pointerdown and commit nothing.
+   *
+   * `onUp(true)` would persist the half-dragged width and fire
+   * `requestStateChange()`, which is the opposite of what Escape and
+   * `pointercancel` mean.
+   */
+  const onAbort = (): void => {
+    const state = resizeState;
+    if (state) {
+      const col = grid._visibleColumns[state.colIndex];
+      if (col) {
+        col.width = state.startConfiguredWidth;
+        col.__renderedWidth = state.startRenderedWidth;
+        col.__userResized = state.startUserResized;
+        grid.updateTemplate?.();
+        grid.dispatchEvent(new CustomEvent('column-resize', { detail: { field: col.field, width: state.startWidth } }));
+      }
+      // The user was dragging, not clicking — still swallow the trailing click
+      // so aborting on a header does not also trigger a sort.
+      justFinishedResize = true;
+      requestAnimationFrame(() => {
+        justFinishedResize = false;
+      });
+    }
+    // `false` — restore cursor/user-select and clear state without committing.
+    onUp(false);
   };
 
   /**
@@ -77,8 +140,14 @@ export function createResizeController(grid: GridHost): ResizeController {
     get isResizing() {
       return resizeState !== null || justFinishedResize;
     },
-    start(e, colIndex, cell) {
-      e.preventDefault();
+    start(rawEvent, colIndex, cell, captureTarget) {
+      const e = toPointerEvent(rawEvent);
+      rawEvent.preventDefault();
+
+      // A second start() while a drag is in flight would orphan the first
+      // gesture's listeners and pointer capture.
+      cancelDrag?.();
+      cancelDrag = null;
 
       // Freeze flexible columns before resizing so they hold their current width
       const headerRow = grid._headerRowEl ?? grid.findHeaderRow?.();
@@ -91,13 +160,31 @@ export function createResizeController(grid: GridHost): ResizeController {
       // Only use numeric widths; string widths (e.g., "100px", "20%") fall back to bounding rect
       const colWidth = typeof col?.width === 'number' ? col.width : undefined;
       const startWidth = col?.__renderedWidth ?? colWidth ?? cell.getBoundingClientRect().width;
-      resizeState = { startX: e.clientX, colIndex, startWidth };
-      window.addEventListener('mousemove', onMove);
-      window.addEventListener('mouseup', onUp);
+      resizeState = {
+        startX: e.clientX,
+        colIndex,
+        startWidth,
+        startConfiguredWidth: col?.width,
+        startRenderedWidth: col?.__renderedWidth,
+        startUserResized: col?.__userResized ?? false,
+      };
       if (prevCursor === null) prevCursor = document.documentElement.style.cursor;
       document.documentElement.style.cursor = 'e-resize';
       if (prevUserSelect === null) prevUserSelect = document.body.style.userSelect;
       document.body.style.userSelect = 'none';
+
+      const target = captureTarget ?? cell;
+      cancelDrag = startPointerDrag(e, target, {
+        onMove,
+        onEnd: () => {
+          cancelDrag = null;
+          onUp(true);
+        },
+        onCancel: () => {
+          cancelDrag = null;
+          onAbort();
+        },
+      });
     },
     resetColumn(colIndex) {
       const col = grid._visibleColumns[colIndex];
@@ -113,7 +200,11 @@ export function createResizeController(grid: GridHost): ResizeController {
       grid.dispatchEvent(new CustomEvent('column-resize-reset', { detail: { field: col.field, width: col.width } }));
     },
     dispose() {
-      onUp();
+      // Tear down an in-flight drag first, or its pointer capture and listeners
+      // outlive the grid. The returned canceller is idempotent.
+      cancelDrag?.();
+      cancelDrag = null;
+      onUp(resizeState !== null);
       // Drop any in-flight template update — the grid (or its DOM) is going
       // away, so the queued `updateTemplate()` would run against stale refs.
       if (pendingRaf != null) {

--- a/libs/grid/src/lib/core/types.ts
+++ b/libs/grid/src/lib/core/types.ts
@@ -2083,7 +2083,20 @@ export interface EditorExecContext<T = any> extends CellContext<T> {
  * @since 0.1.1
  */
 export interface ResizeController {
-  start: (e: MouseEvent, colIndex: number, cell: HTMLElement) => void;
+  /**
+   * Begin a column resize drag.
+   *
+   * @param e - The originating `pointerdown` event. A `mousedown` `MouseEvent`
+   *   is still accepted for backwards compatibility (the grid used mouse events
+   *   before v3.5.0) and is treated as the primary mouse pointer, but new code
+   *   should pass a `PointerEvent` so pen and touch work too.
+   * @param colIndex - Index into `grid._visibleColumns`.
+   * @param cell - Header cell being resized (used as a width fallback).
+   * @param captureTarget - Element that holds pointer capture for the duration
+   *   of the drag. Defaults to `cell`. Pass the resize handle so the drag
+   *   keeps tracking once the pointer leaves the header.
+   */
+  start: (e: MouseEvent | PointerEvent, colIndex: number, cell: HTMLElement, captureTarget?: Element) => void;
   /** Reset a column to its configured width (or auto-size if none configured). */
   resetColumn: (colIndex: number) => void;
   dispose: () => void;

--- a/libs/grid/src/lib/plugins/shell/shell.css
+++ b/libs/grid/src/lib/plugins/shell/shell.css
@@ -279,6 +279,10 @@
       cursor: col-resize;
       background: transparent;
       z-index: 10;
+      /* The splitter drag is driven by pointer capture, so the browser must not
+         claim the gesture for panning on touch devices. */
+      touch-action: none;
+      user-select: none;
       transition: background var(--tbw-transition-duration) var(--tbw-transition-ease);
 
       &[data-handle-position='left'] {

--- a/libs/grid/src/lib/plugins/shell/shell.ts
+++ b/libs/grid/src/lib/plugins/shell/shell.ts
@@ -8,6 +8,7 @@
  */
 
 import { TOOL_PANEL_DUPLICATE, TOOL_PANEL_MISSING_ATTR, warnDiagnostic } from '../../core/internal/diagnostics';
+import { startPointerDrag } from '../../core/internal/pointer-drag';
 import { escapeHtml, sanitizeHTML } from '../../core/internal/sanitize';
 import type { IconValue } from '../../core/types';
 import type { HeaderContentDefinition, ShellConfig, ToolbarContentDefinition, ToolPanelDefinition } from './types';
@@ -799,8 +800,9 @@ export function setupToolPanelResize(
   let startWidth = 0;
   let maxWidth = 0;
   let isResizing = false;
+  let cancelDrag: (() => void) | null = null;
 
-  const onMouseMove = (e: MouseEvent) => {
+  const onMove = (e: PointerEvent) => {
     if (!isResizing) return;
     e.preventDefault();
 
@@ -812,23 +814,32 @@ export function setupToolPanelResize(
     panel.style.width = `${newWidth}px`;
   };
 
-  const onMouseUp = () => {
+  /**
+   * Restore chrome after a drag. `commit` is false when the drag was aborted
+   * (pointercancel / Escape), in which case the caller has already restored the
+   * original width and no `onResize` notification should fire.
+   */
+  const finish = (commit: boolean) => {
     if (!isResizing) return;
     isResizing = false;
+    cancelDrag = null;
     handle.classList.remove('resizing');
     panel.style.transition = ''; // Re-enable transition
     document.body.style.cursor = '';
     document.body.style.userSelect = '';
 
-    // Get final width and notify
-    const finalWidth = panel.getBoundingClientRect().width;
-    onResize(finalWidth);
-
-    document.removeEventListener('mousemove', onMouseMove);
-    document.removeEventListener('mouseup', onMouseUp);
+    if (commit) {
+      // Get final width and notify
+      const finalWidth = panel.getBoundingClientRect().width;
+      onResize(finalWidth);
+    }
   };
 
-  const onMouseDown = (e: MouseEvent) => {
+  const onPointerDown = (e: PointerEvent) => {
+    if (isResizing) return;
+    // Only the primary mouse button starts a splitter drag — a right-click must
+    // keep its context menu rather than being preventDefault()-ed away.
+    if (e.button !== 0 && e.pointerType === 'mouse') return;
     e.preventDefault();
     isResizing = true;
     startX = e.clientX;
@@ -840,17 +851,24 @@ export function setupToolPanelResize(
     document.body.style.cursor = 'col-resize';
     document.body.style.userSelect = 'none';
 
-    document.addEventListener('mousemove', onMouseMove);
-    document.addEventListener('mouseup', onMouseUp);
+    cancelDrag = startPointerDrag(e, handle, {
+      onMove,
+      onEnd: () => finish(true),
+      onCancel: () => {
+        // Aborted (pointercancel / Escape) — snap back to the pre-drag width.
+        panel.style.width = `${startWidth}px`;
+        finish(false);
+      },
+    });
   };
 
-  handle.addEventListener('mousedown', onMouseDown);
+  handle.addEventListener('pointerdown', onPointerDown);
 
   // Return cleanup function
   return () => {
-    handle.removeEventListener('mousedown', onMouseDown);
-    document.removeEventListener('mousemove', onMouseMove);
-    document.removeEventListener('mouseup', onMouseUp);
+    handle.removeEventListener('pointerdown', onPointerDown);
+    cancelDrag?.();
+    cancelDrag = null;
   };
 }
 // #endregion


### PR DESCRIPTION
Part of #302. **Stacked on #442** — review that first; this PR's diff is only meaningful against `feat/gh-307-pointer-modality`.

Closes #303

## What

Converts every mouse-driven drag in the grid to **Pointer Events + pointer capture**, so mouse, pen and touch follow one code path instead of a touch fork that drifts.

New shared primitive: `libs/grid/src/lib/core/internal/pointer-drag.ts`

```ts
startPointerDrag(startEvent, captureTarget, handlers, options?) => cancelFn
```

- Promotion strategies: synchronous, distance `threshold`, or `longPressDuration` (any move past `longPressSlop` before the timer fires cancels the drag — it was a scroll).
- Escape cancels via a single capture-phase `document` listener.
- Re-entrancy guarded by a `WeakMap<Element, Set<number>>`.

Converted: column resize (`resize.ts`, `header.ts`), the shell tool-panel splitter, and cell-range painting in `event-delegation.ts`. All document-level `mousemove`/`mouseup` listeners are gone — pointer capture keeps the gesture on one element.

**Cell-range paint is the one gesture that differs by modality:** fine pointers drag immediately, coarse pointers need a 400 ms long-press first, so a plain swipe still scrolls.

## Design notes

- The coarse/fine branch reads **`e.pointerType` per event**, not the `(pointer: coarse)` media query. On a hybrid device (Surface) the query reports coarse even while a mouse is in use; `getPrimaryPointer()` is only the fallback for synthetic events with no `pointerType`.
- `touch-action: none` is applied **only in `onPromote`**, never on `pointerdown` — otherwise a swipe over the grid gets swallowed. Restored in both `onEnd` and `onCancel`.

## Testing

3798 pass (incl. 24 new `pointer-drag.spec.ts` tests and a rewritten `resize.spec.ts`). Lint + build clean; `index.js` 45.38 kB gz — over the 45 kB soft warning, under the 50 kB hard limit.

> ⚠️ e2e not executed.

## Unblocks

`pointer-drag.ts` is deliberately generic so #228 (DnD pointer conversion) can consume it — that issue was never implemented, which is why this PR owns the module.