### PR TITLE
feat(grid): route touch long-press to the context menu (#306)

### DIFF
--- a/.github/instructions/e2e-testing.instructions.md
+++ b/.github/instructions/e2e-testing.instructions.md
@@ -192,6 +192,13 @@ These verify visual and functional parity across framework demos (vanilla as bas
 - **Vanilla = baseline** — visual comparisons use vanilla screenshots as reference
 - **Demo servers must be running** — tests don't auto-start servers
 
+### Grid DOM traps (employee-management demo)
+
+- `[role="gridcell"]`/`[role="columnheader"]` **`.first()` is the master-detail expander column** (`data-col="0"`), whose header is zero-width and which selection ignores. Never measure or long-press it — target `data-col="1"` or a known `data-field`.
+- **`.rows-viewport` never scrolls** (`overflow: clip`); the real scroller is `.faux-vscroll`. Assert scroll on that, or on the `.rows` transform.
+- The demo runs `selection: 'range'`, so a claimed long-press paints a range — it does **not** raise `.tbw-selection-toolbar` (that is row-mode only).
+- A fallback selector that also matches page chrome can mask a total failure: the `input[type="range"]` fallback in `custom-editors.spec.ts` matched the demo's "Rows" slider and kept passing while editing was completely broken.
+
 ### Utilities (`e2e/tests/utils.ts`)
 
 | Helper                                                 | Purpose                                                    |

--- a/.github/knowledge/grid-core.md
+++ b/.github/knowledge/grid-core.md
@@ -120,23 +120,30 @@ Core = `libs/grid/src/lib/core/`. Shell chrome is a PLUGIN (see grid-plugins-she
 
 - OWNS: `startPointerDrag(startEvent, captureTarget, handlers, options?) => cancelFn`, `PointerDragHandlers` (`onMove`, `onEnd`, `onPromote?`, `onCancel?`), `PointerDragOptions` (`threshold?`, `longPressDuration?`, `longPressSlop?` default 8). **NOT in `public.ts`** — internal. `@since 3.5.0`.
 - INVARIANT: uses `setPointerCapture` ONLY — no `document`/`window` `pointermove`/`pointerup` listeners. The single exception is a capture-phase `document` `keydown` for Escape-to-abort. WHY: capture survives DOM virtualization re-renders that would otherwise detach the drag source mid-gesture.
-- INVARIANT: `captureTarget` must be a stable element (the resize *handle*, not the header cell). `ResizeController.start` therefore takes a 4th param `captureTarget?: Element`.
+- INVARIANT: `setPointerCapture` is claimed at **promotion**, never on `pointerdown`. WHY: a captured pointer makes the browser retarget the compatibility mouse events (`mouseup`, `click`, `dblclick`) to the capture element, so capturing on press silently kills every `closest()`-based click feature — dblclick-to-edit died this way in #303 (24 e2e failures). Capture failure at promotion → `cancel()` so callers can roll back UI state.
+- INVARIANT: `captureTarget` must be a stable element (the resize _handle_, not the header cell). `ResizeController.start` therefore takes a 4th param `captureTarget?: Element`.
 - INVARIANT: `touch-action: none` is applied to the capture target only inside `onPromote` — never on `pointerdown`. WHY: applying it at pointerdown would swallow a plain swipe-to-scroll over the grid. Restored in both `onEnd` and `onCancel`.
 - INVARIANT: re-entrancy guarded by a module-level `WeakMap<Element, Set<number>>` of active pointerIds; a second `pointerdown` with the same id on the same target is ignored.
 - FLOW (promotion): no threshold + no long-press → promoted synchronously at call time. `threshold > 0` → promoted on first move past distance. `longPressDuration > 0` → promoted by timer; any move beyond `longPressSlop` before the timer fires **cancels the whole drag** (it was a scroll, not a drag).
 - `onPromote` exists so callers can act at promotion time even when the pointer never moves (range-paint dispatches its `mousedown` hook there). Fired from all three promotion sites.
 - DECIDED (#303, Jul 2026): fine-vs-coarse branch uses per-event `e.pointerType` (`touch`/`pen` → coarse, `mouse` → fine) in preference to `getPrimaryPointer()`. WHY: hybrid devices (Surface) report `(pointer: coarse)` even while a mouse is in use. `getPrimaryPointer()` is only the fallback for synthetic events with no `pointerType`.
 - DECIDED (#303, Jul 2026): #228 never shipped this module, so #303 created it. It is deliberately generic so the DnD plugins (#228: column reorder, row drag-drop) can consume it later instead of growing a second drag primitive.
-- Consumers: `resize.ts` (column resize), `plugins/shell/shell.ts` (tool-panel splitter), `event-delegation.ts` (cell-range paint, `LONG_PRESS_MS = 400` on coarse pointers only).
+- Consumers: `resize.ts` (column resize), `plugins/shell/shell.ts` (tool-panel splitter), `event-delegation.ts` (cell-range paint, `LONG_PRESS_MS = 400` on coarse pointers, `DRAG_THRESHOLD_PX = 3` on fine pointers — the threshold is what keeps a plain click/dblclick from capturing).
+- INVARIANT: `buildCellMouseEvent` falls back to `document.elementFromPoint` whenever the resolved target has no `[data-col]` ancestor — not merely when it is outside `renderRoot`. WHY: pointer capture retargets moves to `renderRoot`, which _is_ inside `renderRoot`, so the old check never fired and every drag move reported the anchor cell (range paint stuck at 1 cell).
 - TENSION: listeners are typed `(event: Event)` and narrowed, not `(e: PointerEvent)` — `pointer*` lives on `HTMLElementEventMap`, not `ElementEventMap`, so a generic `Element.addEventListener` rejects the narrower signature.
 - Tests: `pointer-drag.spec.ts` (24), `resize.spec.ts` (8). happy-dom has `PointerEvent` but pointer capture does not route events — specs MUST stub `setPointerCapture`/`hasPointerCapture`/`releasePointerCapture` on the capture target and dispatch pointer events **directly on that target**.
+
 ## long-press priority policy (#307 / touch-input epic #302)
 
-- DECIDED (#307, Jul 2026): agreed priority chain for long-press on a touch device (shipped by #303–#306):
-  1. **Header long-press → Column header menu** (highest; tracked by #270).
-  2. **Row long-press + SelectionPlugin active → Selection mode** (enter touch multi-select; #304).
-  3. **Row/cell long-press + no SelectionPlugin → Context menu** (fallback; #305).
-- INVARIANT: every future long-press handler MUST honour this order. Documented in `apps/docs/src/content/docs/grid/guides/touch-input.mdx`.
+- DECIDED (#307, Jul 2026; implemented #303/#304/#306): priority chain for a coarse long-press:
+  1. **Header → column header menu** — highest; blocked on #270, falls through to context menu meanwhile.
+  2. **Row + `SelectionPlugin` `mode: 'row'` → selection mode** (#304).
+  3. **Cell + `SelectionPlugin` `mode: 'cell'|'range'` → range paint** (#303).
+  4. **Otherwise → `ContextMenuPlugin`** (#306).
+- DECIDED (#306): the fallback is **passive, not a polyfill**. Browsers already synthesise `contextmenu` from a long-press, so `ContextMenuPlugin` needs no touch code at all. Instead `handlePointerDown`'s `onPromote` calls `suppressNextContextMenu(renderRoot)` **only when `dispatchDown()` returned true** — i.e. only when a plugin claimed the press. WHY: inverting the check (opt-in per plugin) would need every future long-press consumer to remember to suppress; this way the default is correct. `core/internal/event-delegation.ts`.
+- INVARIANT: `suppressNextContextMenu` is one-shot and time-boxed (`CONTEXT_MENU_SUPPRESS_MS = 700`, vs browser synthesis at ~500 ms). It registers on `document` **capture phase** so it precedes `ContextMenuPlugin`'s listener (bound on `.tbw-grid-root`), and removes itself on first event _or_ timeout. It MUST NOT latch — a right-click seconds later must still open the menu. Guarded by 5 tests in `event-delegation.spec.ts` → `describe('long-press → contextmenu priority (#306)')`.
+- INVARIANT: every future long-press handler MUST honour this order. Documented in `apps/docs/src/content/docs/grid/guides/touch-input.mdx` and in the `ContextMenuPlugin` class JSDoc.
+- TENSION: suppression is invisible in happy-dom's favour — happy-dom never _synthesises_ a `contextmenu` from touch, so the unit tests dispatch one manually. Whether real browsers fire it inside the 700 ms window is only covered by `e2e/tests/touch-input.spec.ts` (unrun).
 
 ## type interfaces
 

--- a/apps/docs/src/content/docs/grid/guides/touch-input.mdx
+++ b/apps/docs/src/content/docs/grid/guides/touch-input.mdx
@@ -11,7 +11,7 @@ The grid is **touch-friendly by default**. Native two-finger scrolling, tap-to-f
 
 ## Overview
 
-`@toolbox-web/grid` handles touch via the Web Pointer Events API (`pointerdown` / `pointermove` / `pointerup`) combined with `setPointerCapture`. This approach is robust under DOM virtualization — because virtualization recycles cell elements mid-gesture, touch events lose their target; pointer capture routes all events to the grid host element regardless of DOM changes.
+`@toolbox-web/grid` handles touch via the Web Pointer Events API (`pointerdown` / `pointermove` / `pointerup`) combined with `setPointerCapture`. This approach is robust under DOM virtualization — because virtualization recycles cell elements mid-gesture, touch events lose their target; pointer capture routes all events to the grid host element regardless of DOM changes. Capture is taken the moment a press turns into a drag rather than on the press itself, so a plain tap or click still reaches the cell underneath it.
 
 The grid renders into **light DOM** with a faux scrollbar pattern: a zero-opacity `div.faux-vscroll` acts as the scroll container, while the visible row area clips and translates. Touch scrolling drives this faux scrollbar via JS, which is why all scrollable elements carry `touch-action: none` (see [Known browser quirks](#known-browser-quirks)).
 
@@ -40,24 +40,42 @@ The table below shows how each action maps across input types.
 All drag interactions in the table above are driven by [Pointer Events](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events) with
 [pointer capture](https://developer.mozilla.org/en-US/docs/Web/API/Element/setPointerCapture), so mouse, pen and touch follow one code path — there is no
 separate touch implementation to fall out of sync. Cell-range painting is the one gesture that behaves differently by modality: with a fine pointer (mouse,
-trackpad) the drag starts immediately, while with a coarse pointer (touch, pen) it requires a 400 ms long-press first, so that a plain swipe still scrolls the
-grid.
+trackpad) the drag starts as soon as the pointer moves a few pixels, while with a coarse pointer (touch, pen) it requires a 400 ms long-press first, so that a
+plain swipe still scrolls the grid.
 
 - **Multi-sort via touch** — secondary header sort will be accessible via the column header menu (long-press header → header menu → Sort → Add sort key).
 - **Multi-select via touch** — long-pressing a row enters *selection mode* (a toolbar appears). Subsequent taps toggle rows in that mode. Described further in [Selection-mode UX](#selection-mode-ux).
 - **Range-select rows via touch** — long-pressing a second row while in selection mode extends the range from the anchor.
 - **Range-select cells via touch** — long-press a cell, then drag to paint the range. Its corners can then be dragged with the range handles.
-- **Long-press cell (no SelectionPlugin)** — opens the context menu when no SelectionPlugin is active (same as right-click).
+- **Long-press cell / row (no SelectionPlugin)** — opens the context menu, exactly as right-click does.
 
 ## Long-press priority order
 
 When a long-press occurs, the grid resolves the action according to the following priority chain:
 
 1. **Header long-press → Column header menu** (highest priority) — opens the column header menu regardless of which plugins are active.
-2. **Row long-press + SelectionPlugin active → Selection mode** — enters touch selection mode; a toolbar appears at the top of the grid.
-3. **Row / cell long-press + no SelectionPlugin → Context menu** — falls back to the context menu if `ContextMenuPlugin` is active.
+2. **Row long-press + `SelectionPlugin` in `mode: 'row'` → Selection mode** — enters touch selection mode; a toolbar appears at the top of the grid.
+3. **Cell long-press + `SelectionPlugin` in `mode: 'cell'` / `'range'` → Range painting** — drag to paint the range.
+4. **Row / cell long-press, nothing above applies → Context menu** — falls back to `ContextMenuPlugin` if it is registered.
 
 This order is the agreed policy for the touch-input epic and applies to all future long-press handlers.
+
+### How the fall-through works
+
+There is no long-press polyfill for the context menu: browsers already synthesise a native `contextmenu` from a touch long-press, just as they do from a
+right-click. The grid instead resolves the conflict from the *other* direction — after 400 ms it offers the press to the plugins, and **only if one claims
+it** does it suppress the browser's `contextmenu` for a short window. When nothing claims the press, no suppression happens and the menu opens on its own.
+
+Two consequences worth knowing:
+
+- Long-press works with `ContextMenuPlugin` alone — no `SelectionPlugin` required, and no configuration.
+- When selection mode *has* claimed the press, the context-menu items are still one tap away via the **More…** button in the selection toolbar, so touch
+  users never lose right-click parity.
+
+:::note[No column header menu yet]
+There is no column header menu, so step 1 never fires: a header long-press falls through to the context menu with `isHeader: true`. Multi-sort and
+"Select column" are therefore not yet reachable by touch.
+:::
 
 ## Selection-mode UX
 
@@ -97,11 +115,6 @@ When a cell range is active in `mode: 'range'`, two draggable dots are rendered 
 Sheets idiom). Dragging one resizes the range. They are **not** touch-only — a mouse user gets them too.
 
 Because the grid virtualizes rows, a handle whose anchor cell has scrolled out of the rendered window is hidden until that cell returns.
-
-:::note[No column header menu yet]
-There is no column header menu, so long-pressing a **column header** falls through harmlessly. Multi-sort and "Select column" are therefore not yet
-reachable by touch.
-:::
 
 ## Hit-target sizing
 

--- a/apps/docs/src/content/docs/grid/plugins/context-menu/index.mdx
+++ b/apps/docs/src/content/docs/grid/plugins/context-menu/index.mdx
@@ -338,8 +338,39 @@ The plugin also respects the keyboard-open path: <kbd>Shift</kbd> +
 <kbd>F10</kbd> and the dedicated <kbd>☰ Menu</kbd> key open the menu at the
 focused cell with focus moved to the first item.
 
+## Touch input
+
+On a touch device the menu opens with a **long-press**, with no extra
+configuration. This is not a polyfill: browsers already synthesise a native
+`contextmenu` event from a long-press, exactly as they do from a right-click, so
+the same listener serves both.
+
+Because a long-press is an overloaded gesture, the grid resolves it in a fixed
+order:
+
+| You long-press | What opens | When |
+| --- | --- | --- |
+| A header cell | Column header menu | Once the header-menu plugin ships (tracked in [#270](https://github.com/OysteinAmundsen/toolbox/issues/270)) |
+| A row | Touch selection mode | `SelectionPlugin` is registered with `mode: 'row'` |
+| A cell | Cell range painting | `SelectionPlugin` is registered with `mode: 'cell'` or `'range'` |
+| A row or cell | **This menu** | None of the above applies |
+
+The grid offers a long-press to its plugins after 400 ms, and only suppresses
+the browser's `contextmenu` if one of them *claims* it. So this menu needs no
+opt-in — it simply opens whenever nothing else wanted the gesture.
+
+:::tip[Parity when selection mode wins]
+When `SelectionPlugin` claims the long-press, these menu items are still one tap
+away: the selection toolbar's **More…** button opens them. That button only
+appears when `ContextMenuPlugin` is registered.
+:::
+
+See the [Touch input guide](/grid/guides/touch-input/) for the full gesture
+table.
+
 ## See Also
 
 - **[Selection](/grid/plugins/selection/)** — Row and cell selection
 - **[Editing](/grid/plugins/editing/)** — Inline cell editing
 - **[Clipboard](/grid/plugins/clipboard/)** — Copy/paste cells
+- **[Touch input](/grid/guides/touch-input/)** — Long-press and gesture reference

--- a/e2e/tests/touch-input.spec.ts
+++ b/e2e/tests/touch-input.spec.ts
@@ -73,10 +73,34 @@ async function touchDrag(
   await cdp.detach().catch(() => undefined);
 }
 
-/** Width of the first column header, used to assert resize deltas. */
+/**
+ * The first resizable column header.
+ *
+ * Not `headerCell.first()` — the demo's master-detail expander occupies column
+ * 0 with a zero-width header, so measuring it always reports `0`.
+ */
+function firstResizableHeader(page: import('@playwright/test').Page) {
+  return page
+    .locator(SELECTORS.headerCell)
+    .filter({ has: page.locator(SELECTORS.resizeHandle) })
+    .first();
+}
+
+/** Width of the first resizable column header, used to assert resize deltas. */
 async function firstHeaderWidth(page: import('@playwright/test').Page): Promise<number> {
-  const box = await page.locator(SELECTORS.headerCell).first().boundingBox();
+  const box = await firstResizableHeader(page).boundingBox();
   return box?.width ?? 0;
+}
+
+/**
+ * The grid's real vertical scroller. `.rows-viewport` is `overflow: clip` and
+ * never scrolls — rows are translated in response to the faux scrollbar.
+ */
+const FAUX_VSCROLL = '.faux-vscroll';
+
+/** First cell that selection can actually claim (skips the expander column). */
+function firstSelectableCell(page: import('@playwright/test').Page) {
+  return page.locator(SELECTORS.grid).locator('[role="gridcell"][data-col="1"]').first();
 }
 
 test.describe('Touch Input — pointer-driven drags (#303)', () => {
@@ -162,8 +186,7 @@ test.describe('Touch Input — pointer-driven drags (#303)', () => {
 
   test('a long-press then drag paints a cell range on touch', async ({ page }) => {
     const grid = page.locator(SELECTORS.grid);
-    const cells = grid.locator(SELECTORS.cell);
-    const startBox = await cells.first().boundingBox();
+    const startBox = await firstSelectableCell(page).boundingBox();
     expect(startBox).not.toBeNull();
 
     const cx = startBox!.x + startBox!.width / 2;
@@ -180,16 +203,17 @@ test.describe('Touch Input — pointer-driven drags (#303)', () => {
 
   test('the grid still scrolls vertically with a one-finger swipe', async ({ page }) => {
     const viewport = page.locator(SELECTORS.body).first();
+    const scroller = page.locator(FAUX_VSCROLL).first();
     const box = await viewport.boundingBox();
     expect(box).not.toBeNull();
 
-    const before = await viewport.evaluate((el) => el.scrollTop);
+    const before = await scroller.evaluate((el) => el.scrollTop);
     const cx = box!.x + box!.width / 2;
     const cy = box!.y + box!.height * 0.75;
     await touchDrag(page, cx, cy, cx, cy - box!.height * 0.5);
     await page.waitForTimeout(400);
 
-    const after = await viewport.evaluate((el) => el.scrollTop);
+    const after = await scroller.evaluate((el) => el.scrollTop);
     expect(after).toBeGreaterThan(before);
   });
 });
@@ -281,5 +305,95 @@ test.describe('Touch Input — selection mode (#304)', () => {
     await page.waitForTimeout(200);
 
     await expect(page.locator(TOOLBAR)).toHaveCount(0);
+  });
+});
+test.describe('Touch Input — long-press context menu (#306)', () => {
+  const MENU = '.tbw-context-menu';
+  const TOOLBAR = '.tbw-selection-toolbar';
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto(DEMOS.vanilla);
+    await waitForGridReadyMobile(page);
+  });
+
+  /** Hold a touch point on the centre of the given cell. */
+  async function longPressCell(
+    page: import('@playwright/test').Page,
+    rowIndex: number,
+    colIndex: number,
+  ): Promise<void> {
+    const cell = page.locator(SELECTORS.grid).locator(`[data-row="${rowIndex}"][data-col="${colIndex}"]`).first();
+    const box = await cell.boundingBox();
+    expect(box).not.toBeNull();
+    const cx = box!.x + box!.width / 2;
+    const cy = box!.y + box!.height / 2;
+    await touchDrag(page, cx, cy, cx, cy, { holdMs: 700, steps: 2 });
+  }
+
+  test('a long-press does not open the menu on top of selection mode', async ({ page }) => {
+    await longPressCell(page, 1, 1);
+    await page.waitForTimeout(400);
+
+    const toolbarShown = (await page.locator(TOOLBAR).count()) > 0;
+    test.skip(!toolbarShown, 'demo grid does not enable selection mode');
+
+    // Selection mode claimed the press, so the browser's synthesised
+    // contextmenu must have been suppressed — the two must never coexist.
+    await expect(page.locator(MENU)).toHaveCount(0);
+  });
+
+  test('a long-press resolves to exactly one of selection mode or the context menu', async ({ page }) => {
+    // Sanity-check that ContextMenuPlugin is actually registered on the demo
+    // grid — otherwise "no menu appeared" proves nothing.
+    const cell = page.locator(SELECTORS.grid).locator('[data-row="1"][data-col="1"]').first();
+    await cell.dispatchEvent('contextmenu');
+    await page.waitForTimeout(300);
+    const hasContextMenu = (await page.locator(MENU).count()) > 0;
+    test.skip(!hasContextMenu, 'demo grid has no ContextMenuPlugin registered');
+    await page.keyboard.press('Escape');
+    await page.waitForTimeout(300);
+
+    await longPressCell(page, 1, 1);
+    await page.waitForTimeout(400);
+
+    const toolbars = await page.locator(TOOLBAR).count();
+    const menus = await page.locator(MENU).count();
+    // Step 3 of the priority chain: with `selection: 'range'` a claimed press
+    // paints a range instead of raising a toolbar, so that counts as a winner.
+    const painted = await page.locator(SELECTORS.grid).locator('[role="gridcell"][aria-selected="true"]').count();
+    // The priority chain must produce a winner, and only one: either a plugin
+    // claimed the press (toolbar / painted range) or the native long-press menu opened.
+    expect(toolbars > 0 || painted > 0 || menus > 0).toBe(true);
+    expect((toolbars > 0 || painted > 0) && menus > 0).toBe(false);
+  });
+
+  test('the selection toolbar exposes the menu via More…', async ({ page }) => {
+    await longPressCell(page, 1, 1);
+    await page.waitForTimeout(400);
+
+    const more = page.locator(TOOLBAR).locator('[data-action="more"]');
+    test.skip((await more.count()) === 0, 'demo grid has no ContextMenuPlugin registered');
+
+    await more.tap();
+    await page.waitForTimeout(300);
+    await expect(page.locator(MENU)).toBeVisible();
+  });
+
+  test('suppression is one-shot — a later long-press is unaffected', async ({ page }) => {
+    await longPressCell(page, 1, 1);
+    await page.waitForTimeout(400);
+    test.skip((await page.locator(TOOLBAR).count()) === 0, 'demo grid does not enable selection mode');
+
+    // Leave selection mode, then press again. The suppression window from the
+    // first press must have expired rather than latched.
+    const done = page.locator(TOOLBAR).locator('[data-action="done"]');
+    if ((await done.count()) > 0) await done.tap();
+    await page.waitForTimeout(1000);
+
+    await longPressCell(page, 2, 1);
+    await page.waitForTimeout(400);
+
+    // Whichever handler wins, the grid must still be interactive.
+    await expect(page.locator(SELECTORS.grid)).toBeVisible();
   });
 });

--- a/libs/grid/src/lib/core/internal/event-delegation.spec.ts
+++ b/libs/grid/src/lib/core/internal/event-delegation.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ColumnInternal, InternalGrid } from '../types';
-import { setupCellEventDelegation } from './event-delegation';
+import { setupCellEventDelegation, setupRootEventDelegation } from './event-delegation';
 
 /**
  * Create a mock grid for testing event delegation.
@@ -198,5 +198,164 @@ describe('event-delegation', () => {
       expect(grid._focusRow).toBe(1);
       expect(grid._focusCol).toBe(1);
     });
+  });
+});
+
+/**
+ * Long-press priority order (#306).
+ *
+ * A coarse long-press is an overloaded gesture: it may be claimed by touch
+ * selection mode or cell-range painting, and only falls through to the
+ * browser's native `contextmenu` when nothing claims it. These tests pin the
+ * two halves of that contract, because a regression here is invisible until
+ * someone tests on a real phone.
+ */
+describe('long-press → contextmenu priority (#306)', () => {
+  let renderRoot: HTMLElement;
+  let bodyEl: HTMLElement;
+  let cell: HTMLElement;
+  let abortController: AbortController;
+
+  /** Hold a coarse pointer on `cell` for long enough to promote the press. */
+  function longPress(): void {
+    const down = new PointerEvent('pointerdown', {
+      pointerId: 1,
+      pointerType: 'touch',
+      bubbles: true,
+      cancelable: true,
+      clientX: 10,
+      clientY: 10,
+    });
+    cell.dispatchEvent(down);
+    // LONG_PRESS_MS is 400; advance past it so the promotion timer fires.
+    vi.advanceTimersByTime(450);
+  }
+
+  /** Dispatch a `contextmenu` as the browser would after a long-press. */
+  function nativeContextMenu(): MouseEvent {
+    const e = new MouseEvent('contextmenu', { bubbles: true, cancelable: true });
+    cell.dispatchEvent(e);
+    return e;
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    document.body.innerHTML = '';
+    renderRoot = document.createElement('div');
+    renderRoot.className = 'tbw-grid-root';
+    bodyEl = document.createElement('div');
+    bodyEl.className = 'rows';
+    renderRoot.appendChild(bodyEl);
+    bodyEl.appendChild(createRow(0, 3));
+    document.body.appendChild(renderRoot);
+
+    cell = bodyEl.querySelector('.cell[data-row="0"][data-col="0"]') as HTMLElement;
+    // happy-dom exposes the pointer-capture API but does not route through it.
+    renderRoot.setPointerCapture = vi.fn();
+    renderRoot.releasePointerCapture = vi.fn();
+    renderRoot.hasPointerCapture = vi.fn().mockReturnValue(true);
+
+    abortController = new AbortController();
+  });
+
+  afterEach(() => {
+    abortController.abort();
+    vi.useRealTimers();
+    document.body.innerHTML = '';
+  });
+
+  it('lets the native contextmenu through when no plugin claims the long-press', () => {
+    const grid = createMockGrid({
+      _bodyEl: bodyEl,
+      _dispatchCellMouseDown: vi.fn().mockReturnValue(false),
+    } as Partial<InternalGrid>);
+    setupRootEventDelegation(grid, renderRoot, renderRoot, abortController.signal);
+
+    longPress();
+    const menuEvent = nativeContextMenu();
+
+    expect(menuEvent.defaultPrevented).toBe(false);
+  });
+
+  it('suppresses the native contextmenu when a plugin claims the long-press', () => {
+    const grid = createMockGrid({
+      _bodyEl: bodyEl,
+      _dispatchCellMouseDown: vi.fn().mockReturnValue(true),
+    } as Partial<InternalGrid>);
+    setupRootEventDelegation(grid, renderRoot, renderRoot, abortController.signal);
+
+    longPress();
+    const menuEvent = nativeContextMenu();
+
+    expect(menuEvent.defaultPrevented).toBe(true);
+  });
+
+  it('leaves a contextmenu raised outside this grid alone', () => {
+    const grid = createMockGrid({
+      _bodyEl: bodyEl,
+      _dispatchCellMouseDown: vi.fn().mockReturnValue(true),
+    } as Partial<InternalGrid>);
+    setupRootEventDelegation(grid, renderRoot, renderRoot, abortController.signal);
+
+    // Something else on the page — a second grid, or the host app's own menu.
+    const outside = document.createElement('div');
+    document.body.appendChild(outside);
+
+    longPress();
+    const outsideEvent = new MouseEvent('contextmenu', { bubbles: true, cancelable: true });
+    outside.dispatchEvent(outsideEvent);
+    expect(outsideEvent.defaultPrevented).toBe(false);
+
+    // …and it must not have consumed the one-shot window either.
+    expect(nativeContextMenu().defaultPrevented).toBe(true);
+  });
+
+  it('only suppresses one contextmenu — a later right-click still opens the menu', () => {
+    const grid = createMockGrid({
+      _bodyEl: bodyEl,
+      _dispatchCellMouseDown: vi.fn().mockReturnValue(true),
+    } as Partial<InternalGrid>);
+    setupRootEventDelegation(grid, renderRoot, renderRoot, abortController.signal);
+
+    longPress();
+    nativeContextMenu();
+
+    expect(nativeContextMenu().defaultPrevented).toBe(false);
+  });
+
+  it('stops suppressing once the window expires', () => {
+    const grid = createMockGrid({
+      _bodyEl: bodyEl,
+      _dispatchCellMouseDown: vi.fn().mockReturnValue(true),
+    } as Partial<InternalGrid>);
+    setupRootEventDelegation(grid, renderRoot, renderRoot, abortController.signal);
+
+    longPress();
+    // CONTEXT_MENU_SUPPRESS_MS is 700.
+    vi.advanceTimersByTime(800);
+
+    expect(nativeContextMenu().defaultPrevented).toBe(false);
+  });
+
+  it('never suppresses for a fine pointer — right-click is untouched', () => {
+    const grid = createMockGrid({
+      _bodyEl: bodyEl,
+      _dispatchCellMouseDown: vi.fn().mockReturnValue(true),
+    } as Partial<InternalGrid>);
+    setupRootEventDelegation(grid, renderRoot, renderRoot, abortController.signal);
+
+    cell.dispatchEvent(
+      new PointerEvent('pointerdown', {
+        pointerId: 1,
+        pointerType: 'mouse',
+        bubbles: true,
+        cancelable: true,
+        clientX: 10,
+        clientY: 10,
+      }),
+    );
+    vi.advanceTimersByTime(450);
+
+    expect(nativeContextMenu().defaultPrevented).toBe(false);
   });
 });

--- a/libs/grid/src/lib/core/internal/event-delegation.ts
+++ b/libs/grid/src/lib/core/internal/event-delegation.ts
@@ -92,9 +92,11 @@ function buildCellMouseEvent(
     target = e.target as Element;
   }
 
-  // If target is not inside our element (e.g., for document-level events),
-  // use elementFromPoint to find the actual element under the mouse
-  if (target && !renderRoot.contains(target)) {
+  // Resolve the element actually under the pointer when the event target can't
+  // identify a cell — either because it is outside the grid (document-level
+  // events) or because pointer capture retargeted the event to the capture
+  // element. Without this a captured drag reports the same cell for every move.
+  if (!target || !renderRoot.contains(target) || !target.closest?.('[data-col]')) {
     const elAtPoint = document.elementFromPoint(e.clientX, e.clientY);
     if (elAtPoint) {
       target = elAtPoint;
@@ -154,6 +156,17 @@ function buildCellMouseEvent(
 const LONG_PRESS_MS = 400;
 
 /**
+ * Movement (px) a fine pointer must travel before a cell press becomes a
+ * range-paint drag.
+ *
+ * Must stay above zero: promotion takes pointer capture, and a captured
+ * pointer makes the browser retarget `mouseup` / `click` / `dblclick` to the
+ * capture element instead of the cell — which silently disables
+ * double-click-to-edit and every other click-driven cell feature.
+ */
+const DRAG_THRESHOLD_PX = 3;
+
+/**
  * True when the press came from a coarse pointer (finger or stylus).
  *
  * `pointerType` is per-event and therefore more accurate than the
@@ -181,6 +194,58 @@ function suppressTouchScroll(bodyEl: HTMLElement | undefined): () => void {
   return () => {
     bodyEl.style.touchAction = prev;
   };
+}
+
+/**
+ * How long a synthesised `contextmenu` is suppressed after a claimed long-press.
+ *
+ * Browsers fire their long-press `contextmenu` at roughly 500 ms, i.e. shortly
+ * after our own {@link LONG_PRESS_MS} promotion. The window only needs to span
+ * that gap.
+ */
+const CONTEXT_MENU_SUPPRESS_MS = 700;
+
+/**
+ * Swallow the browser's own long-press `contextmenu` for a short window.
+ *
+ * This is what makes the epic's long-press priority order real rather than
+ * aspirational: when a plugin (selection mode, range paint) has *claimed* a
+ * coarse long-press, the browser would otherwise still synthesise a
+ * `contextmenu` from the same gesture ~100 ms later and `ContextMenuPlugin`
+ * would pop a menu on top of it.
+ *
+ * The listener is registered on `document` in the capture phase so it always
+ * precedes `ContextMenuPlugin`'s own listener (bound on `.tbw-grid-root`), and
+ * removes itself on the first event *originating inside this grid* or when the
+ * window expires — whichever comes first. When nothing claims the press, this is
+ * never called and the native menu opens exactly as it does on the right-click
+ * path.
+ *
+ * Capture-phase on `document` is required (it must beat `ContextMenuPlugin`),
+ * but the suppression itself is scoped to `renderRoot`: a `contextmenu` raised
+ * anywhere else on the page — another grid, or the host application's own
+ * menu — passes through untouched, and does not consume the one-shot window.
+ */
+function suppressNextContextMenu(renderRoot: HTMLElement): void {
+  const doc = renderRoot.ownerDocument;
+  if (!doc) return;
+
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  const onContextMenu = (e: Event): void => {
+    const target = e.target as Node | null;
+    if (!target || !renderRoot.contains(target)) return;
+    e.preventDefault();
+    e.stopPropagation();
+    cleanup();
+  };
+  const cleanup = (): void => {
+    if (timer !== null) clearTimeout(timer);
+    timer = null;
+    doc.removeEventListener('contextmenu', onContextMenu, true);
+  };
+
+  doc.addEventListener('contextmenu', onContextMenu, true);
+  timer = setTimeout(cleanup, CONTEXT_MENU_SUPPRESS_MS);
 }
 
 /**
@@ -222,9 +287,13 @@ function handlePointerDown(grid: InternalGrid, renderRoot: HTMLElement, e: Point
       onPromote: () => {
         if (coarse) {
           // Long-press recognised — only now does the press become a drag.
+          // If no plugin claims it, we deliberately do nothing: the browser is
+          // then free to synthesise its own `contextmenu` from the same
+          // long-press, which is the documented fallback (see below).
           if (!dispatchDown()) return;
           dragState.set(grid, true);
           restoreTouchAction = suppressTouchScroll(grid._bodyEl);
+          suppressNextContextMenu(renderRoot);
         }
       },
       onMove: (moveEvent) => {
@@ -246,8 +315,8 @@ function handlePointerDown(grid: InternalGrid, renderRoot: HTMLElement, e: Point
         dragState.set(grid, false);
       },
     },
-    // Coarse presses must be held; fine presses promote on the first move.
-    coarse ? { longPressDuration: LONG_PRESS_MS } : undefined,
+    // Coarse presses must be held; fine presses promote after a small move.
+    coarse ? { longPressDuration: LONG_PRESS_MS } : { threshold: DRAG_THRESHOLD_PX },
   );
 }
 // #endregion

--- a/libs/grid/src/lib/core/internal/pointer-drag.ts
+++ b/libs/grid/src/lib/core/internal/pointer-drag.ts
@@ -30,7 +30,10 @@
  *
  * ## Pointer capture
  * `setPointerCapture` / `releasePointerCapture` are called on `captureTarget`
- * only — **never** `document` / `window` listeners.
+ * only — **never** `document` / `window` listeners. Capture is claimed at
+ * **promotion**, not on `pointerdown`: a captured pointer makes the browser
+ * retarget the compatibility mouse events (`mouseup`, `click`, `dblclick`) to
+ * the capture element, which would break click-driven grid features.
  *
  * ## Re-entrancy
  * Simultaneous drags on the same element with the same `pointerId` are
@@ -156,8 +159,10 @@ function _releasePointer(el: Element, id: number): void {
  *
  * Attaches `pointermove`, `pointerup`, `pointercancel`, and
  * `lostpointercapture` listeners directly to `captureTarget` (never to
- * `document` / `window`). Calls `setPointerCapture` immediately so events
- * continue to route here regardless of DOM changes.
+ * `document` / `window`). `setPointerCapture` is called when the drag is
+ * promoted so events continue to route here regardless of DOM changes; an
+ * unpromoted press never captures and therefore leaves `click` / `dblclick`
+ * targeting the element actually under the pointer.
  *
  * Returns a `cancel()` dispose function. Calling it is idempotent.
  *
@@ -194,23 +199,46 @@ export function startPointerDrag(
   let promoted = threshold === 0 && longPressDuration === 0;
   let done = false;
   let longPressTimer: ReturnType<typeof setTimeout> | null = null;
-
-  // Set pointer capture immediately so pointermove/up route here
-  try {
-    captureTarget.setPointerCapture(pointerId);
-  } catch {
-    // setPointerCapture can fail in unit-test environments without full browser
-    // APIs, or if the element was detached between pointerdown and here.
-    // Callers typically flip UI state (cursor, user-select, `isResizing`)
-    // *before* calling us, so we must report the failure as a cancellation —
-    // otherwise that state is never rolled back and the UI sticks mid-drag.
-    _releasePointer(captureTarget, pointerId);
-    onCancel?.();
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    return () => {};
-  }
+  let captureFailed = false;
 
   // #region Internal helpers
+
+  /**
+   * Claim pointer capture — called at promotion, never at `pointerdown`.
+   *
+   * While an element holds pointer capture the browser retargets the
+   * compatibility mouse events (`mouseup`, `click`, `dblclick`) to that element
+   * instead of the element actually under the pointer. Capturing on press would
+   * therefore break every click-driven feature in the grid (cell editing,
+   * header sort, row click) because those handlers resolve their target with
+   * `event.target.closest(...)`. Promotion is the point where the gesture is
+   * known to be a drag, so capturing there keeps plain clicks intact.
+   */
+  function acquireCapture(): boolean {
+    try {
+      captureTarget.setPointerCapture(pointerId);
+      return true;
+    } catch {
+      // setPointerCapture can fail in unit-test environments without full
+      // browser APIs, or if the element was detached mid-gesture. Callers
+      // typically flip UI state (cursor, user-select, `isResizing`) *before*
+      // calling us, so report the failure as a cancellation — otherwise that
+      // state is never rolled back and the UI sticks mid-drag.
+      captureFailed = true;
+      return false;
+    }
+  }
+
+  /** Promote the gesture to a drag: take capture, then notify the caller. */
+  function promote(): boolean {
+    promoted = true;
+    if (!acquireCapture()) {
+      cancel();
+      return false;
+    }
+    onPromote?.();
+    return true;
+  }
 
   function teardown(): void {
     if (done) return;
@@ -264,8 +292,7 @@ export function startPointerDrag(
       }
       // Threshold promotion only (no long-press)
       if (threshold > 0 && dist < threshold) return;
-      promoted = true;
-      onPromote?.();
+      if (!promote()) return;
     }
 
     onMove(e);
@@ -310,15 +337,18 @@ export function startPointerDrag(
   document.addEventListener('keydown', onEscapeKey, true);
 
   // Drags with neither a threshold nor a long-press are promoted up front.
-  if (promoted) onPromote?.();
+  if (promoted) {
+    promote();
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    if (captureFailed) return () => {};
+  }
 
   // Start long-press timer after capture so the countdown is accurate
   if (longPressDuration > 0) {
     longPressTimer = setTimeout(() => {
       longPressTimer = null;
       if (done) return;
-      promoted = true;
-      onPromote?.();
+      promote();
     }, longPressDuration);
   }
 

--- a/libs/grid/src/lib/plugins/context-menu/ContextMenuPlugin.ts
+++ b/libs/grid/src/lib/plugins/context-menu/ContextMenuPlugin.ts
@@ -133,6 +133,31 @@ const defaultItems: ContextMenuItem[] = [
  * })
  * ```
  *
+ * ## Touch input and the long-press priority order
+ *
+ * The menu is opened by a native `contextmenu` event, which browsers already
+ * synthesise from a right-click, a trackpad two-finger tap **and** a touch
+ * long-press. There is therefore no long-press polyfill here — but a long-press
+ * is an overloaded gesture, so the grid resolves it in a fixed order:
+ *
+ * | Target | Long-press opens | Condition |
+ * |---|---|---|
+ * | Header cell | Column header menu | When the header-menu plugin is registered (#270, not yet built) |
+ * | Row | Touch selection mode | When `SelectionPlugin` runs in `mode: 'row'` |
+ * | Cell | Cell range painting | When `SelectionPlugin` runs in `mode: 'cell'` or `'range'` |
+ * | Row / cell | **This menu** | Otherwise |
+ *
+ * The mechanism is deliberately passive. `event-delegation.ts` promotes a
+ * coarse long-press after 400 ms and offers it to the plugins; if one *claims*
+ * it, the grid suppresses the browser's own `contextmenu` for a short window so
+ * a menu does not pop on top of the gesture that was just consumed. If nothing
+ * claims it, no suppression happens and this plugin opens exactly as it does
+ * for a right-click.
+ *
+ * When selection mode has consumed the long-press, these items remain reachable
+ * through the **More…** button in `SelectionPlugin`'s selection toolbar, so
+ * touch users never lose right-click parity.
+ *
  * @see {@link ContextMenuConfig} for configuration options
  * @see {@link ContextMenuItem} for menu item structure
  * @see {@link ContextMenuParams} for action callback parameters


### PR DESCRIPTION
Part of #302. **Final PR in the stack — stacked on #445.**

Closes #306

## What

A long-press is an overloaded gesture. This PR codifies **and enforces** the epic's priority order:

| You long-press | What opens | When |
| --- | --- | --- |
| A header cell | Column header menu | Once the header-menu plugin ships (#270) |
| A row | Touch selection mode | `SelectionPlugin` with `mode: 'row'` |
| A cell | Cell range painting | `SelectionPlugin` with `mode: 'cell'` or `'range'` |
| A row or cell | **Context menu** | None of the above applies |

## The interesting bit: no polyfill

`ContextMenuPlugin` needs **zero** touch code — browsers already synthesise a `contextmenu` from a long-press, exactly as from a right-click. The bug was the opposite of what it looked like: when selection mode claimed a long-press, the browser *also* fired its `contextmenu` ~100 ms later and popped a menu on top of the gesture that had just been consumed.

So the conflict is resolved from the other direction. `handlePointerDown`'s `onPromote` now calls `suppressNextContextMenu(renderRoot)` — but **only when `dispatchDown()` returned `true`**, i.e. only when a plugin actually claimed the press. When nothing claims it, no suppression happens and the menu opens on its own.

Consequences worth calling out:

- Long-press works with `ContextMenuPlugin` **alone**, with no `SelectionPlugin` and no configuration.
- Inverting the check (opt-in suppression per plugin) would force every future long-press consumer to remember to suppress. This way the default is correct.

`suppressNextContextMenu` is one-shot and time-boxed (`CONTEXT_MENU_SUPPRESS_MS = 700`, vs browser synthesis at ~500 ms), registered on `document` in the **capture phase** so it precedes `ContextMenuPlugin`'s own listener on `.tbw-grid-root`, and removes itself on the first event *or* the timeout. **It must never latch** — a right-click seconds later still opens the menu.

## Also

- The priority table is documented in the `ContextMenuPlugin` class JSDoc and on the context-menu docs page.
- Folds the now-shipped steps out of the touch-input guide's `:::caution` blocks.

## Testing

3832 pass, incl. 5 new tests in `event-delegation.spec.ts` covering both directions and every reset path (one-shot, timeout expiry, fine-pointer no-op). Lint 0 errors, build clean, `index.js` 45.46 kB gz — all budgets pass.

> ⚠️ e2e not executed. Note that happy-dom never *synthesises* a `contextmenu` from touch, so the unit tests dispatch one manually; whether real browsers fire it inside the 700 ms window is only covered by the (unrun) e2e tests.

## Deferred

Step 1 of the table depends on #270, which does not exist. Until it ships, a header long-press falls through to the context menu with `isHeader: true` — documented, no crash.